### PR TITLE
Multiple dbus_interface methods

### DIFF
--- a/lib/dbus/export.rb
+++ b/lib/dbus/export.rb
@@ -73,8 +73,10 @@ module DBus
     # belong to.
     def self.dbus_interface(s)
       @@intfs_mutex.synchronize do
-        @@cur_intf = Interface.new(s)
-        self.intfs = (self.intfs || {}).merge({s => @@cur_intf})
+        unless @@cur_intf = (self.intfs && self.intfs[s])
+          @@cur_intf = Interface.new(s)
+          self.intfs = (self.intfs || {}).merge({s => @@cur_intf})
+        end
         yield
         @@cur_intf = nil
       end


### PR DESCRIPTION
I want to use multiple dbus_interface methods of same interface names.
But, dbus_interface makes no effort except for latest method call.
So, I change the program not to create a new Dbus::Interface object
when Dbus::Interface has already been created by dbus_interface.
I'm wondering if you merge my commit.
