### PR TITLE
Sub-par bug fix

### DIFF
--- a/lib/dbus/marshall.rb
+++ b/lib/dbus/marshall.rb
@@ -23,7 +23,7 @@ module DBus
   # Class that handles the conversion (unmarshalling) of payload data
   # to Array.
   class PacketUnmarshaller
-    # Index pointer that points to the byte in the data that is 
+    # Index pointer that points to the byte in the data that is
     # currently being processed.
     #
     # Used to kown what part of the buffer has been consumed by unmarshalling.
@@ -272,6 +272,7 @@ module DBus
     # Append the the string _str_ itself to the packet.
     def append_string(str)
       align(4)
+      str = str.join if str.is_a?(Array) # hackity hack hack
       @packet += [str.bytesize].pack("L") + [str].pack("Z*")
     end
 
@@ -406,7 +407,7 @@ module DBus
         end
       else
         raise NotImplementedError,
-	  "sigtype: #{type.sigtype} (#{type.sigtype.chr})"     
+	  "sigtype: #{type.sigtype} (#{type.sigtype.chr})"
       end
     end # def append
 
@@ -439,6 +440,7 @@ module DBus
           ["x", i]
         end
       end
-    end    
+    end
   end # class PacketMarshaller
 end # module DBus
+


### PR DESCRIPTION
I say "sub-par" because I'm not sure why this fixes the bug, but it does.

Right now I am encountering the following error:
    carl@ubuntu:~/scripts$ ruby songbus.rb 
    /home/carl/.rvm/gems/ruby-1.8.7-p334@clean-test/gems/ruby-dbus-0.6.0/lib/dbus/marshall.rb:276:in `+': can't convert Array into String (TypeError)
        from /home/carl/.rvm/gems/ruby-1.8.7-p334@clean-test/gems/ruby-dbus-0.6.0/lib/dbus/marshall.rb:276:in`append_string'
        from /home/carl/.rvm/gems/ruby-1.8.7-p334@clean-test/gems/ruby-dbus-0.6.0/lib/dbus/marshall.rb:350:in `append'
        from /home/carl/.rvm/gems/ruby-1.8.7-p334@clean-test/gems/ruby-dbus-0.6.0/lib/dbus/message.rb:153:in`marshall'
        from /home/carl/.rvm/gems/ruby-1.8.7-p334@clean-test/gems/ruby-dbus-0.6.0/lib/dbus/message.rb:152:in `each'
        from /home/carl/.rvm/gems/ruby-1.8.7-p334@clean-test/gems/ruby-dbus-0.6.0/lib/dbus/message.rb:152:in`marshall'
        from /home/carl/.rvm/gems/ruby-1.8.7-p334@clean-test/gems/ruby-dbus-0.6.0/lib/dbus/bus.rb:543:in `send_sync'
        from (eval):22:in`getSongProperties'
        from songbus.rb:13

songbus.rb:
    require 'rubygems'
    require 'dbus'

```
bus = DBus::SessionBus.instance
# get a rb object
player_proxy = bus.introspect("org.gnome.Rhythmbox", "/org/gnome/Rhythmbox/Player")
 shell_proxy = bus.introspect("org.gnome.Rhythmbox", "/org/gnome/Rhythmbox/Shell")

player = player_proxy["org.gnome.Rhythmbox.Player"]
shell  = shell_proxy["org.gnome.Rhythmbox.Shell"]

uri = player.getPlayingUri()
song = shell.getSongProperties(uri)
artist = song[0]['artist']; title = song[0]['title']

puts "#{artist} - #{title}"
```

Output after I made the change shown in this commit:
    carl@ubuntu:~/scripts$ ruby songbus.rb 
    Death Cab for Cutie - Blacking Out The Friction

Hope this hack helps you find the root cause. I'm not good enough with binary formats to help much.
