### PR TITLE
Handle D-Bus initial null byte properly on BSD

### DIFF
--- a/lib/dbus/auth.rb
+++ b/lib/dbus/auth.rb
@@ -8,6 +8,8 @@
 
 $debug = $DEBUG #it's all over the state machine
 
+require 'rbconfig'
+
 module DBus
   # Exception raised when authentication fails somehow.
   class AuthenticationFailed < Exception
@@ -118,7 +120,11 @@ module DBus
 
     # Start the authentication process.
     def authenticate
-      @socket.write(0.chr)
+      if (RbConfig::CONFIG["target_os"] =~ /bsd/)
+        @socket.sendmsg(0.chr, 0, nil, [:SOCKET, :SCM_CREDS, ""])
+      else
+        @socket.write(0.chr)
+      end
       next_authenticator
       @state = :Starting
       while @state != :Authenticated


### PR DESCRIPTION
Added check for *BSD so the initial null byte is sent properly on BSD (since it has SCM_CREDS)
- Note: This is pretty hackish and should probably be improved
