### PR TITLE
Fix DBus::Main#run method

### DIFF
--- a/lib/dbus/bus.rb
+++ b/lib/dbus/bus.rb
@@ -827,8 +827,8 @@ module DBus
         end
       end
       while not @quitting and not @buses.empty?
-        ready = IO.select(@buses.keys,[],[],5) #timeout 5 seconds
-        continue unless ready #timeout exceed so continue unless quitting
+        ready = IO.select(@buses.keys, [], [], 5) # timeout 5 seconds
+        next unless ready # timeout exceeds so continue unless quitting
         ready.first.each do |socket|
           b = @buses[socket]
           begin


### PR DESCRIPTION
There is no continue keyword in ruby.
