### PR TITLE
Add UNIX_FD type signature.

### DIFF
--- a/lib/dbus/marshall.rb
+++ b/lib/dbus/marshall.rb
@@ -146,7 +146,7 @@ module DBus
         if (packet & 0x8000) != 0
           packet -= 0x10000
         end
-      when Type::UINT32
+      when Type::UINT32, Type::UNIX_FD
         align(4)
         packet = get(4).unpack(@uint32)[0]
       when Type::INT32
@@ -317,7 +317,7 @@ module DBus
       case type.sigtype
       when Type::BYTE
         @packet += val.chr
-      when Type::UINT32
+      when Type::UINT32, Type::UNIX_FD
         align(4)
         @packet += [val].pack("L")
       when Type::UINT64

--- a/lib/dbus/type.rb
+++ b/lib/dbus/type.rb
@@ -33,6 +33,7 @@ module Type
   STRING = ?s
   SIGNATURE = ?g
   DICT_ENTRY = ?e
+  UNIX_FD = ?h
 
   # Mapping from type number to name.
   TypeName = {
@@ -52,7 +53,8 @@ module Type
     OBJECT_PATH => "OBJECT_PATH",
     STRING => "STRING",
     SIGNATURE => "SIGNATURE",
-    DICT_ENTRY => "DICT_ENTRY"
+    DICT_ENTRY => "DICT_ENTRY",
+    UNIX_FD => "UNIX_FD"
   }
 
   # Exception raised when an unknown/incorrect type is encountered.
@@ -96,6 +98,7 @@ module Type
         OBJECT_PATH => 4,
         STRING => 4,
         SIGNATURE => 1,
+        UNIX_FD => 4,
       }[@sigtype]
     end
 


### PR DESCRIPTION
Discovered on Ubuntu 12.04 (dbus-1.4.18, upstart-1.5) by running the following snippet.

``` ruby
require 'dbus'

bus = DBus::SystemBus.instance
bus.service('com.ubuntu.Upstart').object('/com/ubuntu/Upstart').introspect
```

That throws the following exception.

```
/.../gems/ruby-dbus-0.7.2/lib/dbus/type.rb:74:in `initialize': Unknown key in signature: h (DBus::Type::SignatureException)
    from /.../gems/ruby-dbus-0.7.2/lib/dbus/type.rb:191:in `new'
    from /.../gems/ruby-dbus-0.7.2/lib/dbus/type.rb:191:in `parse_one'
    from /.../gems/ruby-dbus-0.7.2/lib/dbus/type.rb:201:in `parse'
```

See the following link for the UNIX_FD type details.
http://dbus.freedesktop.org/doc/dbus-specification.html#message-protocol-signatures
