### PR TITLE
Abstract XML parsing to support multiple backends; Add nokogiri support

### DIFF
--- a/test/bus_and_xml_backend_test.rb
+++ b/test/bus_and_xml_backend_test.rb
@@ -1,0 +1,42 @@
+#!/usr/bin/env ruby
+# Test the bus class
+require "test/unit"
+require 'rubygems'
+require 'nokogiri'
+require "dbus"
+
+class BusTest < Test::Unit::TestCase
+  def setup
+    @bus = DBus::ASessionBus.new
+  end
+
+  def test_introspection_reading_rexml
+    DBus::IntrospectXMLParser.backend = DBus::IntrospectXMLParser::REXMLParser
+    @svc = @bus.service("org.ruby.service")
+    obj = @svc.object("/org/ruby/MyInstance")
+    obj.default_iface = 'org.ruby.SampleInterface'
+    obj.introspect
+    assert_nothing_raised do
+      assert_equal 42, obj.the_answer[0], "should respond to :the_answer"
+    end
+    assert_nothing_raised do
+      assert_equal "oof", obj["org.ruby.AnotherInterface"].Reverse('foo')[0], "should work with multiple interfaces"
+    end
+  end
+
+  def test_introspection_reading_nokogiri
+    # peek inside the object to see if a cleanup step worked or not
+    DBus::IntrospectXMLParser.backend = DBus::IntrospectXMLParser::NokogiriParser
+    @svc = @bus.service("org.ruby.service")
+    obj = @svc.object("/org/ruby/MyInstance")
+    obj.default_iface = 'org.ruby.SampleInterface'
+    obj.introspect
+    assert_nothing_raised do
+      assert_equal 42, obj.the_answer[0], "should respond to :the_answer"
+    end
+    assert_nothing_raised do
+      assert_equal "oof", obj["org.ruby.AnotherInterface"].Reverse('foo')[0], "should work with multiple interfaces"
+    end
+  end
+
+end


### PR DESCRIPTION
I find in desktop applications that introspection of DBUS can make an app feel much more sluggish than it needs to - and switching out REXML and replacing it with Nokogiri makes a noticeable difference.

Here's a patch that adds a minimal abstraction layer for the XML parsing.

It uses Nokogiri by default (if it can be loaded).
It falls back to REXML if Nokogiri isn't/can't be loaded.
It allows the developer to select the backend using: 
DBus::IntrospectXMLParser.backend = DBus::IntrospectXMLParser::NokogiriParser
or
DBus::IntrospectXMLParser.backend = DBus::IntrospectXMLParser::REXMLParser

and comes with a simple test file which tests introspection using both backends.
