### PR TITLE
Fix #update_buffer to not needlessly block

### DIFF
--- a/lib/dbus/bus.rb
+++ b/lib/dbus/bus.rb
@@ -503,6 +503,9 @@ module DBus
       @buffer += @socket.read_nonblock(MSG_BUF_SIZE)  
     rescue EOFError
       raise                     # the caller expects it
+    rescue Errno::EWOULDBLOCK
+      # simply fail the read if it would block
+      return
     rescue Exception => e
       puts "Oops:", e
       raise if @is_tcp          # why?


### PR DESCRIPTION
I currently have the following in my code:

```
@dbus.update_buffer
@dbus.messages.each do |msg|
  # Pass messages through DBus
  @dbus.process(msg)

  # [snip] Do additional processing on msg
end
```

I'm specifically doing it this way so that I can process DBus messages without blocking, however occasionally I get the following message in the console and `#update_buffer` blocks:

> Resource temporarily unavailable - read would block
> WARNING: read_nonblock failed, falling back to .recv

This usually happens when there is no data to be read, which would coincide nicely with the message given. `#glibize` seems to watch the socket manually to avoid this situation. My question is, as a client to the library how can I avoid this behavior if I specifically don't want to block at all?
