### PR TITLE
Issue29 Allow omitting the interface when calling a remote method

### DIFF
--- a/test/introspection_test.rb
+++ b/test/introspection_test.rb
@@ -15,4 +15,17 @@ class IntrospectionTest < Test::Unit::TestCase
     assert_raise(ArgumentError) { @obj.test_variant "too","many","args" }
     assert_raise(ArgumentError) { @obj.test_variant } # not enough
   end
+
+  def test_shortcut_methods
+    @obj.default_iface = nil
+    assert_equal(["varargs"], @obj.bounce_variant("varargs"))
+    # test for a duplicated method name
+    assert_raise(NoMethodError) { @obj.the_answer }
+    # ensure istance methods of ProxyObject aren't overwritten by remote
+    # methods
+    assert_nothing_raised { @obj.interfaces }
+
+    @obj.default_iface = "org.ruby.SampleInterface"
+    assert_equal [42], @obj.the_answer
+  end
 end

--- a/test/service_newapi.rb
+++ b/test/service_newapi.rb
@@ -80,6 +80,15 @@ class Test < DBus::Object
     end
   end
 
+  dbus_interface "org.ruby.Duplicates" do
+    dbus_method :the_answer, "out answer:i" do
+      [0]
+    end
+    dbus_method :interfaces, "out answer:i" do
+      raise "Raising"
+    end
+  end
+
   dbus_interface "org.ruby.Loop" do
     # starts doing something long, but returns immediately
     # and sends a signal when done
@@ -172,7 +181,7 @@ service.export(myobj)
 derived = Derived.new "/org/ruby/MyDerivedInstance"
 service.export derived
 test2 = Test2.new "/org/ruby/MyInstance2"
-service.export test2 
+service.export test2
 
 # introspect every other connection, Ticket #34
 #  (except the one that activates us - it has already emitted


### PR DESCRIPTION
The default interface of a ProxyObject might be be omitted if there is no collision. This partially solves issue#29, since some remaining code has to be written, to allow omitting the interface when registering a signal.
I hope everything in the commit is fine.
