### PR TITLE
Properly handle unspecified directions in dbus introspection

### DIFF
--- a/lib/dbus/xml.rb
+++ b/lib/dbus/xml.rb
@@ -138,15 +138,21 @@ module DBus
         dir = ae["direction"]
         sig = ae["type"]
 	if m.is_a?(DBus::Signal)
+          if(dir.nil?)
+            dir = "out"
+          end
           m.add_fparam(name, sig)
 	elsif m.is_a?(DBus::Method)
           case dir
           when "in"
             m.add_fparam(name, sig)
           when "out"
-	    m.add_return(name, sig)
-	  end
-        else
+            m.add_return(name, sig)
+          else
+            # This is a method, so dir defaults to "in"
+            m.add_fparam(name, sig)
+	    end
+    else
           raise NotImplementedError, dir
         end
       end

--- a/ruby-dbus.gemspec
+++ b/ruby-dbus.gemspec
@@ -15,6 +15,6 @@ GEMSPEC = Gem::Specification.new do |s|
   s.files = FileList["{doc/tutorial,examples,lib,test}/**/*", "Rakefile", "ruby-dbus.gemspec", "VERSION"].to_a.sort
   s.require_path = "lib"
   s.has_rdoc = true
-  s.extra_rdoc_files = ["COPYING", "README", "NEWS"]
+  s.extra_rdoc_files = ["COPYING", "README.md", "NEWS"]
   s.required_ruby_version = ">= 1.8.7"
 end


### PR DESCRIPTION
Dbus allows the "direction" attribute to be left unspecified, and states that direction can be assumed to be "in" for methods and "out" for signals. This pull request introduces a change that allows ruby-dbus to properly infer unspecified direction attributes. Changelog is below:

dbus spec (http://dbus.freedesktop.org/doc/dbus-specification.html)
states that "The direction element on <arg> may be omitted, in which
case it defaults to "in" for method calls and "out" for signals".

Update ruby-dbus.gemspec to reflect the README -> README.md rename
