### PR TITLE
support /etc/machine-id

### DIFF
--- a/lib/dbus/bus.rb
+++ b/lib/dbus/bus.rb
@@ -741,7 +741,7 @@ module DBus
       return nil unless machine_id_path
       machine_id = File.read(machine_id_path).chomp
 
-      display = ENV["DISPLAY"].gsub(/.*:([0-9]*)\.*/, '\1')
+      display = ENV["DISPLAY"][/:(\d+)\.?/, 1]
 
       bus_file_path = File.join(ENV["HOME"], "/.dbus/session-bus/#{machine_id}-#{display}")
       return nil unless File.exists?(bus_file_path)


### PR DESCRIPTION
Some systems (running systemd) does not have /var/lib/dbus/machine-id but /etc/machine-id.

Since systemd is likely to replace traditional sysv-init in the future, add /etc/machine-id support.

Related information: http://linuxmanpages.net/manpages/fedora15/man5/machine-id.5.html
