### PR TITLE
Add Ruby 2.0 as an option under Requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ D-Bus system can be used in the Ruby programming language.
 
 ## Requirements
 
-- Ruby 1.8.7 or 1.9
+- Ruby 1.8.7, 1.9 or 2.0
 
 ## Installation
 


### PR DESCRIPTION
Tests pass locally in Ruby 2.0 and I saw it has been added to Travis.yml so added to README as well.
