### PR TITLE
Support unix fd as method parameter in own services

### DIFF
--- a/lib/dbus/auth.rb
+++ b/lib/dbus/auth.rb
@@ -263,7 +263,7 @@ module DBus
           return false
         end
       when :WaitingForUnixFd
-         DBus.logger.debug ":WaitingForUnixFd msg: #{msg[0].inspect}"
+        DBus.logger.debug ":WaitingForUnixFd msg: #{msg[0].inspect}"
         case msg[0]
         when "AGREE_UNIX_FD"
           send("BEGIN")


### PR DESCRIPTION
Without this patch i cannot implement a service which contains a method that takes an unix fd as a parameter, e.g.

``` ruby
dbus_method :NewConnection, "in device:o, in fd:h, in fd_properties:a{sv}" do |device, fd, fd_properties|
    puts "NewConnection"
end
```

This method is never called. Insted the following message appears in the dbus log:

```
Serial Port replied with an error: org.freedesktop.DBus.Error.NotSupported, Tried to send message with Unix file descriptorsto a client that doesn't support that.
```

This patch fixes the problem for me.

See [D-Bus documentation](http://dbus.freedesktop.org/doc/dbus-specification.html#auth-command-agree-unix-fd)
See [My example code](https://gist.github.com/chrta/8897809)
