### PR TITLE
Improve DBUS_SESSION_BUS_ADDRESS extraction

### DIFF
--- a/lib/dbus/bus.rb
+++ b/lib/dbus/bus.rb
@@ -602,9 +602,11 @@ module DBus
     end
 
     def self.session_bus_address
-      ENV["DBUS_SESSION_BUS_ADDRESS"] ||
-        address_from_file ||
-        "launchd:env=DBUS_LAUNCHD_SESSION_BUS_SOCKET"
+      if ENV["DBUS_SESSION_BUS_ADDRESS"]
+        ENV["DBUS_SESSION_BUS_ADDRESS"].gsub(/^['"]|['"]$/, '')
+      else
+        address_from_file || "launchd:env=DBUS_LAUNCHD_SESSION_BUS_SOCKET"
+      end
     end
 
     def self.address_from_file
@@ -620,7 +622,7 @@ module DBus
       return nil unless File.exists?(bus_file_path)
 
       File.open(bus_file_path).each_line do |line|
-        if line =~ /^DBUS_SESSION_BUS_ADDRESS=(.*)/
+        if line =~ /^DBUS_SESSION_BUS_ADDRESS='?"?([^'"(\r?\n)]*)'?"?$/
           return $1
         end
       end

--- a/spec/session_bus_spec.rb
+++ b/spec/session_bus_spec.rb
@@ -1,0 +1,84 @@
+#!/usr/bin/env rspec
+require_relative "spec_helper"
+require "dbus"
+
+describe DBus::ASessionBus do
+  subject(:dbus_session_bus_address) { "unix:abstract=/tmp/dbus-foo,guid=123" }
+
+  describe "#session_bus_address" do
+    around(:each) do |example|
+      @original_dbus_session_bus_address = ENV["DBUS_SESSION_BUS_ADDRESS"]
+      example.call
+      ENV["DBUS_SESSION_BUS_ADDRESS"] = @original_dbus_session_bus_address
+    end
+
+    context "when DBUS_SESSION_BUS_ADDRESS env is surrounded by quotation marks" do
+      it "returns session bus address without single quotation marks" do
+        ENV["DBUS_SESSION_BUS_ADDRESS"] = "'#{dbus_session_bus_address}'"
+        expect(DBus::ASessionBus.session_bus_address).to eq(dbus_session_bus_address)
+      end
+
+      it "returns session bus address without double quotation marks" do
+        ENV["DBUS_SESSION_BUS_ADDRESS"] = "\"#{dbus_session_bus_address}\""
+        expect(DBus::ASessionBus.session_bus_address).to eq(dbus_session_bus_address)
+      end
+    end
+
+    context "when DBUS_SESSION_BUS_ADDRESS env is not surrounded by any quotation marks" do
+      it "returns session bus address as it is" do
+        ENV["DBUS_SESSION_BUS_ADDRESS"] = dbus_session_bus_address
+        expect(DBus::ASessionBus.session_bus_address).to eq(dbus_session_bus_address)
+      end
+    end
+  end
+
+  describe "#address_from_file" do
+    let(:session_bus_file_path) { /\.dbus\/session-bus\/baz-\d/ }
+
+    before do
+      # mocks of files for address_from_file method
+      machine_id_path = File.expand_path("/etc/machine-id", __FILE__)
+      expect(Dir).to receive(:[]).with(any_args) {[machine_id_path] }
+      expect(File).to receive(:read).with(machine_id_path) { "baz" }
+      expect(File).to receive(:exists?).with(session_bus_file_path) { true }
+    end
+
+    around(:each) do |example|
+      with_env("DISPLAY", ":0.0") do
+        example.call
+      end
+    end
+
+    context "when DBUS_SESSION_BUS_ADDRESS from file is surrounded by quotation marks" do
+
+      it "returns session bus address without single quotation marks" do
+        expect(File).to receive(:open).with(session_bus_file_path) { <<-EOS.gsub(/^\s*/, '') }
+          DBUS_SESSION_BUS_ADDRESS='#{dbus_session_bus_address}'
+          DBUS_SESSION_BUS_PID=12345
+          DBUS_SESSION_BUS_WINDOWID=12345678
+        EOS
+        expect(DBus::ASessionBus.address_from_file).to eq(dbus_session_bus_address)
+      end
+
+      it "returns session bus address without double quotation marks" do
+        expect(File).to receive(:open).with(session_bus_file_path) { <<-EOS.gsub(/^\s*/, '') }
+          DBUS_SESSION_BUS_ADDRESS="#{dbus_session_bus_address}"
+          DBUS_SESSION_BUS_PID=12345
+          DBUS_SESSION_BUS_WINDOWID=12345678
+        EOS
+        expect(DBus::ASessionBus.address_from_file).to eq(dbus_session_bus_address)
+      end
+    end
+
+    context "when DBUS_SESSION_BUS_ADDRESS from file is not surrounded by any quotation marks" do
+      it "returns session bus address as it is" do
+        expect(File).to receive(:open).with(session_bus_file_path) { <<-EOS.gsub(/^\s*/, '') }
+          DBUS_SESSION_BUS_ADDRESS=#{dbus_session_bus_address}
+          DBUS_SESSION_BUS_PID=12345
+          DBUS_SESSION_BUS_WINDOWID=12345678
+        EOS
+        expect(DBus::ASessionBus.address_from_file).to eq(dbus_session_bus_address)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Hi :-D

I've got following error after update of **dbus** (system dbus, not ruby-dbus)

```zsh
% bundle exec ruby -e 'require "dbus"; DBus::SessionBus.instance'               
/path/to/gems/ruby/2.3.0/gems/ruby-dbus-0.11.1/lib/dbus/message_queue.rb:46:in `push': undefined method `write' for nil:NilClass (NoMethodError)
        from /path/to/gems/ruby/2.3.0/gems/ruby-dbus-0.11.1/lib/dbus/bus.rb:442:in `send_sync'
        from /path/to/gems/ruby/2.3.0/gems/ruby-dbus-0.11.1/lib/dbus/bus.rb:582:in `send_hello'
        from /path/to/gems/ruby/2.3.0/gems/ruby-dbus-0.11.1/lib/dbus/bus.rb:601:in `initialize'        from /path/to/ruby/2.3.0/singleton.rb:142:in `new'                      
        from /path/to/ruby/2.3.0/singleton.rb:142:in `block in instance'        
        from /path/to/ruby/2.3.0/singleton.rb:140:in `synchronize'              
        from /path/to/ruby/2.3.0/singleton.rb:140:in `instance'                    
        from -e:1:in `<main>'
```

The cause of this error was `DBUS_SESSION_BUS_ADDRESS` value surrounded by single quotation from generated file in `~/.dbus/session-bus/#{MACHINE_ID}-#{ENV["DISPLAY"]}`

```zsh
% cat ~/.dbus/session-bus/MACHINE_ID-0 
# This file allows processes on the machine with id MACHINE_ID using 
# display :0.0 to find the D-Bus session bus with the below address.
# If the DBUS_SESSION_BUS_ADDRESS environment variable is set, it will
# be used rather than this file.
# See "man dbus-launch" for more details.
DBUS_SESSION_BUS_ADDRESS='unix:abstract=/tmp/dbus-foo,guid=12345...'
DBUS_SESSION_BUS_PID=...
DBUS_SESSION_BUS_WINDOWID=...
```

If I remove this single quotations from this file, then error has gone.
But I think that It would might be better to support it in **ruby-dbus**.

Then I've just created this pull request ;)
How dou you think about this?

I tested this change in ruby `{2.3.1|1.9.3-p551|2.0.0-p648}` in local.
If I need some thing change about code or style, please tell me.
\# especially, I used some `mocks` at rspec instead of real file for testing or `Tempfile`.

## Improvement

* Add support `DBUS_SESSION_BUS_ADDRESS` value surrounded by quotation marks (`'` and `"`)

## Environment

The OS on my latop is Gentoo Linux.

```zsh
% uname -a
Linux HOSTNAME 4.5.2-gentoo #18 SMP Sun Aug 7 14:23:24 CEST 2016 x86_64 Intel(R) Core(TM) i7-5500U CPU @ 2.40GHz GenuineIntel GNU/Linux
```

The dbus version is `1.10.10`

```zsh
% dbus-launch --version
D-Bus Message Bus Launcher 1.10.10
Copyright (C) 2003 Red Hat, Inc.
This is free software; see the source for copying conditions.
There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
```

I'm using dbus without user session support.
And it is compiled for 32 bit and 64 bit both.

```zsh
% eix sys-apps/dbus
[I] sys-apps/dbus
     Available versions:  1.8.16 (~)1.8.20 1.10.8-r1^t (~)1.10.10^t {X debug doc selinux static-libs systemd test user-session ABI_MIPS="n32 n64 o32" ABI_PPC="32 64" ABI_S390="32 64" ABI_X86="32 64 x32"}
     Installed versions:  1.10.10^t(11:15:09 PM 09/03/2016)(X -debug -doc -selinux -static-libs -systemd -test -user-session ABI_MIPS="-n32 -n64 -o32" ABI_PPC="-32 -64" ABI_S390="-32 -64" ABI_X86="32 64 -x32")
     Homepage:            https://dbus.freedesktop.org/
     Description:         A message bus system, a simple way for applications to talk to each other
```

I'm using ruby-dbus `0.11.1` on ruby `{2.3.1|1.9.3-p551|2.0.0-p648}` :)

```zsh
% bundle list | grep dbus
  * ruby-dbus (0.11.1)
```

thanks