### PR TITLE
Readd singleton_class? for compatibility

### DIFF
--- a/lib/dbus/core_ext/class/attribute.rb
+++ b/lib/dbus/core_ext/class/attribute.rb
@@ -108,4 +108,12 @@ class Class
       end
     end
   end
+
+  private
+
+  unless respond_to?(:singleton_class?)
+    def singleton_class?
+      ancestors.first != self
+    end
+  end
 end


### PR DESCRIPTION
This readds a private singleton_class? method to
stay compatible with ruby 2.0.

closes #78