### PR TITLE
Make dependency to rexml

### DIFF
--- a/ruby-dbus.gemspec
+++ b/ruby-dbus.gemspec
@@ -20,6 +20,8 @@ GEMSPEC = Gem::Specification.new do |s|
 
   s.required_ruby_version = ">= 2.0.0"
 
+  s.add_dependency "rexml"
+
   # This is optional
   # s.add_runtime_dependency "nokogiri"
 


### PR DESCRIPTION
ruby-dbus make crash on load in ruby 3.0.0 .

```
/home/toshi/Project/mikutter/vendor/bundle/mikutter-cli/ruby/3.0.0/gems/ruby-dbus-0.16.0/lib/dbus/xml.rb:13:in `require': cannot load such file -- rexml/document (LoadError)
        from /home/toshi/Project/mikutter/vendor/bundle/mikutter-cli/ruby/3.0.0/gems/ruby-dbus-0.16.0/lib/dbus/xml.rb:13:in `<top (required)>'
```

In ruby 3, rexml becomes bundled gem.
I think ruby-dbus should make dependency to 'rexml'.

see: https://github.com/rails/rails/pull/40281