### PR TITLE
Replace unnecessarily sexual example

### DIFF
--- a/examples/service/call_service.rb
+++ b/examples/service/call_service.rb
@@ -14,7 +14,7 @@ player.test_variant(["s", "coucou"])
 player.on_signal("SomethingJustHappened") do |u, v|
   puts "SomethingJustHappened: #{u} #{v}"
 end
-player.hello("8=======D", "(_._)")
+player.hello("Hey", "there!")
 p player["org.ruby.AnotherInterface"].Reverse("Hello world!")
 
 main = DBus::Main.new


### PR DESCRIPTION
The diff should be self explanatory. Hopefully this is uncontroversial, but this seemed unnecessarily and surprisingly sexual as I was looking for some code examples for `ruby-dbus`. :bowing_man: 