### PR TITLE
CI with GitHub Actions

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -1,0 +1,35 @@
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+# This workflow will download a prebuilt Ruby version, install dependencies and run tests with Rake
+# For more information see: https://github.com/marketplace/actions/setup-ruby-jruby-and-truffleruby
+
+name: Ruby
+
+on:
+  push:
+    branches: [ $default-branch ]
+  pull_request:
+    branches: [ $default-branch ]
+
+jobs:
+  test:
+
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        ruby-version: ['2.6', '2.7', '3.0']
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Ruby
+    # To automatically get bug fixes and new Ruby versions for ruby/setup-ruby,
+    # change this to (see https://github.com/ruby/setup-ruby#versioning):
+    # uses: ruby/setup-ruby@v1
+      uses: ruby/setup-ruby@473e4d8fe5dd94ee328fdfca9f8c9c7afc9dae5e
+      with:
+        ruby-version: ${{ matrix.ruby-version }}
+        bundler-cache: true # runs 'bundle install' and caches installed gems automatically
+    - name: Run tests
+      run: bundle exec rake

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -7,11 +7,7 @@
 
 name: Ruby
 
-on:
-  push:
-    branches: [ $default-branch ]
-  pull_request:
-    branches: [ $default-branch ]
+on: [push, pull_request]
 
 jobs:
   test:

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -30,5 +30,17 @@ jobs:
       with:
         ruby-version: ${{ matrix.ruby-version }}
         bundler-cache: true # runs 'bundle install' and caches installed gems automatically
+
     - name: Run tests
       run: bundle exec rake
+      # enable code coverage reporting
+      env:
+        COVERAGE: 'true'
+        COVERAGE_LCOV: 'true'
+
+    - name: Coveralls Report
+      # send it only for the latest version to avoid duplicate submits
+      if: ${{ matrix.ruby-version == '3.1' }}
+      uses: coverallsapp/github-action@master
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -13,15 +13,11 @@ jobs:
   test:
 
     runs-on: ubuntu-latest
-    continue-on-error: ${{ matrix.experimental }}
+    continue-on-error: ${{ matrix.ruby-version == 'head' }}
     strategy:
       fail-fast: false
       matrix:
-        ruby-version: ['2.5', '2.6', '2.7', '3.0', '3.1']
-        experimental: [false]
-        include:
-          - ruby-version: head
-            experimental: true
+        ruby-version: ['2.5', '2.6', '2.7', '3.0', '3.1', 'head']
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby-version: ['2.5', '2.6', '2.7', '3.0']
+        ruby-version: ['2.5', '2.6', '2.7', '3.0', '3.1']
         experimental: [false]
         include:
           - ruby-version: head
@@ -26,10 +26,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Set up Ruby
-    # To automatically get bug fixes and new Ruby versions for ruby/setup-ruby,
-    # change this to (see https://github.com/ruby/setup-ruby#versioning):
-    # uses: ruby/setup-ruby@v1
-      uses: ruby/setup-ruby@473e4d8fe5dd94ee328fdfca9f8c9c7afc9dae5e
+      uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{ matrix.ruby-version }}
         bundler-cache: true # runs 'bundle install' and caches installed gems automatically

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -13,9 +13,15 @@ jobs:
   test:
 
     runs-on: ubuntu-latest
+    continue-on-error: ${{ matrix.experimental }}
     strategy:
+      fail-fast: false
       matrix:
         ruby-version: ['2.5', '2.6', '2.7', '3.0']
+        experimental: [false]
+        include:
+          - ruby-version: head
+            experimental: true
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby-version: ['2.6', '2.7', '3.0']
+        ruby-version: ['2.5', '2.6', '2.7', '3.0']
 
     steps:
     - uses: actions/checkout@v2

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 /.bundle/
 /.vendor/
 /Gemfile.lock
+.ruby-version
 
 /doc/tutorial/index.html
 /doc/DBus

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -105,7 +105,7 @@ Metrics/BlockLength:
 # Offense count: 8
 # Configuration parameters: CountComments.
 Metrics/ClassLength:
-  Max: 300
+  Max: 303
 
 # Offense count: 12
 Metrics/CyclomaticComplexity:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,6 +2,8 @@ AllCops:
   Exclude:
     # Do not check code borrowed from ActiveSupport
     - 'lib/dbus/core_ext/**/*.rb'
+    # Bundled dependencies
+    - 'vendor/**/*'
     # RPM spec is not RSpec
     - package/rubygem-ruby-dbus.spec
 

--- a/HOWTO-RELEASE
+++ b/HOWTO-RELEASE
@@ -4,7 +4,7 @@ the current packages
 
     rake osc:build
 
-Push, and check the Travis CI results.
+Push, and check the CI results.
 
     git push
 

--- a/README.md
+++ b/README.md
@@ -11,14 +11,13 @@ Ruby D-Bus is a pure Ruby library for writing clients and services for D-Bus.
 [![Coverage Status][CS img]][Coverage Status]
 
 [Gem Version]: https://rubygems.org/gems/ruby-dbus
-[Build Status]: https://travis-ci.org/mvidner/ruby-dbus
-[travis pull requests]: https://travis-ci.org/mvidner/ruby-dbus/pull_requests
+[Build Status]: https://github.com/mvidner/ruby-dbus/actions?query=branch%3Amaster
 [Dependency Status]: https://gemnasium.com/mvidner/ruby-dbus
 [Code Climate]: https://codeclimate.com/github/mvidner/ruby-dbus
 [Coverage Status]: https://coveralls.io/r/mvidner/ruby-dbus
 
 [GV img]: https://badge.fury.io/rb/ruby-dbus.png
-[BS img]: https://travis-ci.org/mvidner/ruby-dbus.png?branch=master
+[BS img]: https://github.com/mvidner/ruby-dbus/workflows/CI/badge.svg?branch=master
 [DS img]: https://gemnasium.com/mvidner/ruby-dbus.png
 [CC img]: https://codeclimate.com/github/mvidner/ruby-dbus.png
 [CS img]: https://coveralls.io/repos/mvidner/ruby-dbus/badge.png?branch=master

--- a/Rakefile
+++ b/Rakefile
@@ -38,7 +38,7 @@ RSpec::Core::RakeTask.new("bare:spec")
   end
 end
 
-if ENV["TRAVIS"]
+if ENV["CI"]
   require "coveralls/rake/task"
   Coveralls::RakeTask.new
   task default: "coveralls:push"

--- a/Rakefile
+++ b/Rakefile
@@ -38,12 +38,6 @@ RSpec::Core::RakeTask.new("bare:spec")
   end
 end
 
-if ENV["CI"]
-  require "coveralls/rake/task"
-  Coveralls::RakeTask.new
-  task default: "coveralls:push"
-end
-
 # remove tarball implementation and create gem for this gemfile
 Rake::Task[:tarball].clear
 

--- a/Rakefile
+++ b/Rakefile
@@ -68,4 +68,20 @@ namespace :doc do
   end
 end
 
-RuboCop::RakeTask.new if Object.const_defined? :RuboCop
+if Object.const_defined? :RuboCop
+  if RUBY_VERSION.start_with?("2.")
+    RuboCop::RakeTask.new
+  else
+    desc "Run RuboCop (dummy)"
+    task :rubocop do
+      warn "The code is not adapted to recent RuboCop yet,\n" \
+           "and the old one no longer works with Ruby 3.x.\n" \
+           "Switch back to Ruby 2.x to run it."
+    end
+  end
+else
+  desc "Run RuboCop (dummy)"
+  task :rubocop do
+    warn "RuboCop not installed"
+  end
+end

--- a/lib/dbus/proxy_object.rb
+++ b/lib/dbus/proxy_object.rb
@@ -44,6 +44,7 @@ module DBus
     end
 
     # Returns the interfaces of the object.
+    # @return [Array<String>] names of the interfaces
     def interfaces
       introspect unless introspected
       @interfaces.keys

--- a/ruby-dbus.gemspec
+++ b/ruby-dbus.gemspec
@@ -25,10 +25,10 @@ GEMSPEC = Gem::Specification.new do |s|
   # This is optional
   # s.add_runtime_dependency "nokogiri"
 
-  s.add_development_dependency "coveralls"
   s.add_development_dependency "packaging_rake_tasks"
   s.add_development_dependency "rake"
   s.add_development_dependency "rspec", "~> 3"
   s.add_development_dependency "rubocop", "= 0.50.0"
   s.add_development_dependency "simplecov"
+  s.add_development_dependency "simplecov-lcov"
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,8 +2,8 @@ coverage = if ENV["COVERAGE"]
              ENV["COVERAGE"] == "true"
            else
              # heuristics: enable for interactive builds (but not in OBS)
-             # or in Travis
-             ENV["DISPLAY"] || ENV["TRAVIS"]
+             # or in Continuous Integration (GitHub Actions)
+             ENV["DISPLAY"] || ENV["CI"]
            end
 
 if coverage
@@ -15,8 +15,8 @@ if coverage
   # do not cover the activesupport helpers
   SimpleCov.add_filter "/core_ext/"
 
-  # use coveralls for on-line code coverage reporting at Travis CI
-  if ENV["TRAVIS"]
+  # use coveralls for on-line code coverage reporting during CI
+  if ENV["CI"]
     require "coveralls"
   end
   SimpleCov.start

--- a/spec/tools/dbus-limited-session.conf
+++ b/spec/tools/dbus-limited-session.conf
@@ -25,4 +25,8 @@
        Instead, lower some so that we can test resource leaks. -->
   <limit name="max_match_rules_per_connection">50</limit><!-- was 512 -->
 
+  <!--
+dbus-daemon[1700]: [session uid=1001 pid=1700] Unable to set up new connection: Failed to get AppArmor confinement information of socket peer: Protocol not available
+  -->
+  <apparmor mode="disabled"/>
 </busconfig>


### PR DESCRIPTION
Travis-CI.ORG is no longer working: https://blog.travis-ci.com/2021-05-07-orgshutdown

**Ruby versions**
- must succeed on currently maintained Rubies: 2.6 to 3.1
- must succeed on 2.5, unmaintained upstream, but included in SLE15
- can fail on `head` Ruby 
- (not caring about 2.1 to 2.4 which were enabled in Travis.)

Code coverage reporting on **Coveralls** works again: https://coveralls.io/github/mvidner/ruby-dbus
(coveralls.gem no longer needed for that)

**Rubocop**: for now disabled on Ruby 3.x until I update the config (and code), see Issue #94