### PR TITLE
Improve D-Bus struct handling: as properties

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,14 @@
 
 ## Unreleased
 
+API:
+ * D-Bus structs have been passed as Ruby arrays. Now these arrays are frozen.
+ * Ruby structs can be used as D-Bus structs.
+
+Bug fixes:
+ * Returning the value for o.fd.DBus.Properties.Get, use the specific property
+   signature, not the generic Variant.
+
 ## Ruby D-Bus 0.17.0 - 2022-02-11
 
 API:

--- a/doc/Reference.md
+++ b/doc/Reference.md
@@ -190,11 +190,18 @@ If the signature expects a Variant
    type. This will hit you when you rely on method (2) but happen to have
    a particular string value in an array.
 
+##### Structs
+
+If a **STRUCT** `(...)` is expected you may pass
+
+- an [Array](https://ruby-doc.org/core/Array.html) (frozen is fine)
+- a [Struct](https://ruby-doc.org/core/Struct.html)
+
 ##### Byte Arrays
 
 If a byte array (`ay`) is expected you can pass a String too.
 The bytes sent are according to the string's
-[encoding](http://ruby-doc.org/core-2.0.0/Encoding.html).
+[encoding](http://ruby-doc.org/core/Encoding.html).
 
 ##### nil
 

--- a/doc/Reference.md
+++ b/doc/Reference.md
@@ -153,7 +153,7 @@ To receive signals for a specific object and interface, use
 
 D-Bus booleans, numbers, strings, arrays and dictionaries become their straightforward Ruby counterparts.
 
-Structs become arrays.
+Structs become frozen arrays.
 
 Object paths become strings.
 

--- a/lib/dbus/marshall.rb
+++ b/lib/dbus/marshall.rb
@@ -212,6 +212,7 @@ module DBus
         signature.members.each do |elem|
           packet << do_parse(elem)
         end
+        packet.freeze
       when Type::VARIANT
         string = read_signature
         # error checking please

--- a/lib/dbus/marshall.rb
+++ b/lib/dbus/marshall.rb
@@ -355,13 +355,18 @@ module DBus
       when Type::ARRAY
         append_array(type.child, val)
       when Type::STRUCT, Type::DICT_ENTRY
-        # TODO: use duck typing, val.respond_to?
-        raise TypeException, "Struct/DE expects an Array" if !val.is_a?(Array)
-        if type.sigtype == Type::DICT_ENTRY && val.size != 2
-          raise TypeException, "Dict entry expects a pair"
+        unless val.is_a?(Array) || val.is_a?(Struct)
+          type_name = Type::TYPE_MAPPING[type.sigtype].first
+          raise TypeException, "#{type_name} expects an Array or Struct"
         end
+
+        if type.sigtype == Type::DICT_ENTRY && val.size != 2
+          raise TypeException, "DICT_ENTRY expects a pair"
+        end
+
         if type.members.size != val.size
-          raise TypeException, "Struct/DE has #{val.size} elements but type info for #{type.members.size}"
+          type_name = Type::TYPE_MAPPING[type.sigtype].first
+          raise TypeException, "#{type_name} has #{val.size} elements but type info for #{type.members.size}"
         end
 
         struct do

--- a/lib/dbus/object.rb
+++ b/lib/dbus/object.rb
@@ -64,7 +64,7 @@ module DBus
           if iface.name == PROPERTY_INTERFACE && member_sym == :Get
             # Use the specific property type instead of the generic variant
             # returned by Get.
-            # GetAll and Set still missing
+            # TODO: GetAll and Set still missing
             property = dbus_lookup_property(msg.params[0], msg.params[1])
             rsigs = [property.type]
           else

--- a/spec/property_spec.rb
+++ b/spec/property_spec.rb
@@ -52,7 +52,7 @@ describe "PropertyTest" do
 
   it "tests get all" do
     all = @iface.all_properties
-    expect(all.keys.sort).to eq(["ReadMe", "ReadOrWriteMe"])
+    expect(all.keys.sort).to eq(["MyStruct", "ReadMe", "ReadOrWriteMe"])
   end
 
   it "tests get all on a V1 object" do
@@ -60,7 +60,7 @@ describe "PropertyTest" do
     iface = obj["org.ruby.SampleInterface"]
 
     all = iface.all_properties
-    expect(all.keys.sort).to eq(["ReadMe", "ReadOrWriteMe"])
+    expect(all.keys.sort).to eq(["MyStruct", "ReadMe", "ReadOrWriteMe"])
   end
 
   it "tests unknown property reading" do
@@ -115,5 +115,12 @@ describe "PropertyTest" do
     quitter.join
 
     expect(received["ReadOrWriteMe"]).to eq("VALUE")
+  end
+
+  context "a struct-typed property" do
+    it "gets read as a struct, not an array (#97)" do
+      struct = @iface["MyStruct"]
+      expect(struct).to be_frozen
+    end
   end
 end

--- a/spec/service_newapi.rb
+++ b/spec/service_newapi.rb
@@ -16,6 +16,7 @@ class Test < DBus::Object
     super path
     @read_me = "READ ME"
     @read_or_write_me = "READ OR WRITE ME"
+    @my_struct = ["three", "strings", "in a struct"].freeze
   end
 
   # Create an interface aggregating all upcoming dbus_method defines.
@@ -60,6 +61,11 @@ class Test < DBus::Object
       [bytes]
     end
 
+    dbus_method :Coordinates, "out coords:(dd)" do
+      coords = [3.0, 4.0].freeze
+      [coords]
+    end
+
     # Properties:
     # ReadMe:string, returns "READ ME" at first, then what WriteMe received
     # WriteMe:string
@@ -79,6 +85,8 @@ class Test < DBus::Object
       raise "Something failed"
     end
     dbus_reader :explosive, "s"
+
+    dbus_attr_reader :my_struct, "(sss)"
   end
 
   # closing and reopening the same interface

--- a/spec/service_newapi.rb
+++ b/spec/service_newapi.rb
@@ -11,6 +11,8 @@ require "dbus"
 PROPERTY_INTERFACE = "org.freedesktop.DBus.Properties"
 
 class Test < DBus::Object
+  Point2D = Struct.new(:x, :y)
+
   INTERFACE = "org.ruby.SampleInterface"
   def initialize(path)
     super path
@@ -63,6 +65,11 @@ class Test < DBus::Object
 
     dbus_method :Coordinates, "out coords:(dd)" do
       coords = [3.0, 4.0].freeze
+      [coords]
+    end
+
+    dbus_method :Coordinates2, "out coords:(dd)" do
+      coords = Point2D.new(5.0, 12.0)
       [coords]
     end
 

--- a/spec/value_spec.rb
+++ b/spec/value_spec.rb
@@ -92,4 +92,12 @@ describe "ValueTest" do
   it "aligns short integers correctly" do
     expect(@obj.i16_plus(10, -30)[0]).to eq(-20)
   end
+
+  context "structs" do
+    it "they are returned as FROZEN arrays" do
+      struct = @obj.Coordinates[0]
+      expect(struct).to be_an(Array)
+      expect(struct).to be_frozen
+    end
+  end
 end

--- a/spec/value_spec.rb
+++ b/spec/value_spec.rb
@@ -99,5 +99,11 @@ describe "ValueTest" do
       expect(struct).to be_an(Array)
       expect(struct).to be_frozen
     end
+
+    it "they are returned also from structs" do
+      struct = @obj.Coordinates2[0]
+      expect(struct).to be_an(Array)
+      expect(struct).to be_frozen
+    end
   end
 end


### PR DESCRIPTION
Responding to #97.

- [x] properly document: unserializing a struct makes a frozen array

### Before

Before this PR, the return signature for getting a property was a Variant:

> org.freedesktop.DBus.Properties.Get(..., ..., out **VARIANT** value)

With no type hint for the Ruby -> D-Bus data conversion, a property with a nontrivial type, such as STRUCT, would get returned incorrectly:

```console
$ busctl --user --list introspect org.ruby.service /org/ruby/MyInstance | grep -E NAME\|MyStruct
NAME                            TYPE      SIGNATURE RESULT/VALUE                            FLAGS
.MyStruct                       property  (sss)     3 s "three" s "strings" s "in a struct" emits-change # not visible here
$ dbus-send --session --print-reply --dest=org.ruby.service /org/ruby/MyInstance org.freedesktop.DBus.Properties.Get string:org.ruby.SampleInterface string:MyStruct
method return time=[...] sender=:1.985 -> destination=:1.987 serial=24 reply_serial=2
   variant       array [
         variant             string "three"
         variant             string "strings"
         variant             string "in a struct"
      ]
```

### After

Now, `Property.Get` has a special case to look at the signature declared for the property itself.
So a STRUCT, ieven though mplemented at the service side as an Array, gets returned as a STRUCT.

```console
$  dbus-send --session --print-reply --dest=org.ruby.service /org/ruby/MyInstance org.freedesktop.DBus.Properties.Get string:org.ruby.SampleInterface string:MyStruct
method return time=[...] sender=:1.990 -> destination=:1.991 serial=12 reply_serial=2
   struct {
      string "three"
      string "strings"
      string "in a struct"
   }
```