### PR TITLE
Make sure DBus.type constructs a valid one

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,12 @@
 
 ## Unreleased
 
+API:
+ * Renamed the DBus::Type::Type class to DBus::Type
+   (which was previously a module).
+
 Bug fixes:
+ * Signature validation: Ensure DBus.type produces a valid Type
  * Detect more malformed messages: non-NUL padding bytes, variants with
    multiple or no value.
 

--- a/doc/Reference.md
+++ b/doc/Reference.md
@@ -171,7 +171,7 @@ by the D-Bus signature.
 If the signature expects a Variant
 (which is the case for all Properties!) then an explicit mechanism is needed.
 
-1. A pair [{DBus::Type::Type}, value] specifies to marshall *value* as
+1. A pair [{DBus::Type}, value] specifies to marshall *value* as
    that specified type.
    The pair can be produced by {DBus.variant}(signature, value) which
    gives the  same result as [{DBus.type}(signature), value].

--- a/lib/dbus/marshall.rb
+++ b/lib/dbus/marshall.rb
@@ -403,7 +403,7 @@ module DBus
       vartype = nil
       if val.is_a?(Array) && val.size == 2
         case val[0]
-        when DBus::Type::Type
+        when Type
           vartype, vardata = val
         when String
           begin
@@ -427,7 +427,7 @@ module DBus
       @packet += sub.packet
     end
 
-    # @param child_type [DBus::Type::Type]
+    # @param child_type [Type]
     def append_array(child_type, val)
       if val.is_a?(Hash)
         raise TypeException, "Expected an Array but got a Hash" if child_type.sigtype != Type::DICT_ENTRY

--- a/spec/type_spec.rb
+++ b/spec/type_spec.rb
@@ -6,15 +6,76 @@ require "dbus"
 
 describe DBus do
   describe ".type" do
-    ["i", "ai", "a(ii)", "aai"].each do |s|
-      it "parses some type #{s}" do
-        expect(DBus.type(s).to_s).to be_eql s
+    good = [
+      "i",
+      "ai",
+      "a(ii)",
+      "aai"
+    ]
+
+    context "valid single types" do
+      good.each do |s|
+        it "#{s.inspect} is parsed" do
+          expect(DBus.type(s).to_s).to eq(s)
+        end
       end
     end
 
-    ["aa", "(ii", "ii)", "hrmp"].each do |s|
-      it "raises exception for invalid type #{s}" do
-        expect { DBus.type(s).to_s }.to raise_error DBus::Type::SignatureException
+    bad = [
+      ["\x00", "Unknown type code"],
+      ["!", "Unknown type code"],
+
+      # ARRAY related
+      ["a", "Empty ARRAY"],
+      ["aa", "Empty ARRAY"],
+
+      # STRUCT related
+      ["r", "Abstract STRUCT"],
+      ["()", "Empty STRUCT"],
+      ["(ii", "STRUCT not closed"],
+      ["a{i)", "STRUCT unexpectedly closed"],
+
+      # TODO: deep nesting arrays, structs, combined
+
+      # DICT_ENTRY related
+      ["e", "Abstract DICT_ENTRY"],
+      ["a{}", "DICT_ENTRY must have 2 subtypes, found 0"],
+      ["a{s}", "DICT_ENTRY must have 2 subtypes, found 1"],
+      ["a{sss}", "DICT_ENTRY must have 2 subtypes, found 3"],
+      ["a{vs}", "DICT_ENTRY key must be basic (non-container)"],
+      ["{sv}", "DICT_ENTRY not an immediate child of an ARRAY"],
+      ["a({sv})", "DICT_ENTRY not an immediate child of an ARRAY"],
+      ["a{sv", "DICT_ENTRY not closed"],
+      ["}", "DICT_ENTRY unexpectedly closed"],
+
+      # Too long
+      ["(#{"y" * 254})", "longer than 255"],
+
+      # not Single Complete Types
+      ["", "expecting a Single Complete Type"],
+      ["ii", "more than a Single Complete Type"]
+    ]
+    context "invalid single types" do
+      bad.each.each do |s, msg|
+        it "#{s.inspect} raises an exception mentioning: #{msg}" do
+          rx = Regexp.new(Regexp.quote(msg))
+          expect { DBus.type(s) }.to raise_error(DBus::Type::SignatureException, rx)
+        end
+      end
+    end
+  end
+
+  describe ".types" do
+    good = [
+      "",
+      "ii"
+    ]
+
+    context "valid signatures" do
+      good.each do |s|
+        it "#{s.inspect} is parsed" do
+          expect(DBus.types(s).map(&:to_s).join).to eq(s)
+        end
       end
     end
   end


### PR DESCRIPTION
This is a subtask of #103 but it is separate enough to make sense as a standalone PR.

Previously it was easy to construct an invalid signature, even for trivially bad cases.

Now, make sure `DBus.type` constructs a valid Single Complete Type, and add `DBus.types` for constructing a valid Signature (0 or more SCTs)

Add test cases.

The corresponding section of the specification is [Type System](https://dbus.freedesktop.org/doc/dbus-specification.html#type-system)

Also, `DBus::Type` was an internal Module and the constructed Class was awkwardly named `DBus::Type::Type`. Merged them (with a compatibility "symlink")
