### PR TITLE
Fix forgotten case: marshall Data::Array as an ARRAY

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+Bug fixes:
+ * Service-side properties: Fix Properties.Get, Properties.GetAll for
+   properties that contain arrays, on other than outermost level ([#109][]).
+
+[#109]: https://github.com/mvidner/ruby-dbus/pull/109
+
 ## Ruby D-Bus 0.18.0.beta3 - 2022-04-10
 
 Bug fixes:

--- a/lib/dbus/marshall.rb
+++ b/lib/dbus/marshall.rb
@@ -250,6 +250,7 @@ module DBus
         when Type::VARIANT
           append_variant(val)
         when Type::ARRAY
+          val = val.value if val.is_a?(Data::Array)
           append_array(type.child, val)
         when Type::STRUCT, Type::DICT_ENTRY
           val = val.value if val.is_a?(Data::Struct) || val.is_a?(Data::DictEntry)

--- a/spec/packet_marshaller_spec.rb
+++ b/spec/packet_marshaller_spec.rb
@@ -29,6 +29,13 @@ describe DBus::PacketMarshaller do
         subject.append(signature, t.val)
         expect(subject.packet).to eq(expected)
       end
+
+      it "writes a '#{signature}' with typed value #{t.val.inspect} (#{endianness})" do
+        subject = described_class.new(endianness: endianness)
+        typed_val = DBus::Data.make_typed(signature, t.val)
+        subject.append(signature, typed_val)
+        expect(subject.packet).to eq(expected)
+      end
     end
   end
 end


### PR DESCRIPTION
A fix for https://github.com/yast/d-installer/issues/126#issuecomment-1101223422

CLI test:
```console
busctl get-property org.opensuse.DInstaller /org/opensuse/DInstaller/Language1 org.opensuse.DInstaller.Language1 AvailableLanguages
```

The existing tests would only catch it if `my_array` was a *nested* array, such as `aaq`