### PR TITLE
When calling Properties.Set in ProxyObjectInterface#[]=, use correct type (#108)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,10 +1,16 @@
 # Ruby D-Bus NEWS
 
+## Unreleased
+
+API:
+ * DBus.variant(type, value) is deprecated in favor of
+   Data::Variant.new(value, member_type:)
+
 Bug fixes:
  * Client-side properties: When calling Properties.Set in
    ProxyObjectInterface#[]=, use the correct type ([#108][]).
 
-## Unreleased
+[#108]: https://github.com/mvidner/ruby-dbus/issues/108
 
 ## Ruby D-Bus 0.18.0.beta6 - 2022-05-25
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # Ruby D-Bus NEWS
 
+Bug fixes:
+ * Client-side properties: When calling Properties.Set in
+   ProxyObjectInterface#[]=, use the correct type ([#108][]).
+
 ## Unreleased
 
 ## Ruby D-Bus 0.18.0.beta6 - 2022-05-25

--- a/doc/Reference.md
+++ b/doc/Reference.md
@@ -166,12 +166,21 @@ D-Bus has stricter typing than Ruby, so the library must decide
 which D-Bus type to choose. Most of the time the choice is dictated
 by the D-Bus signature.
 
+For exact representation of D-Bus data types, use subclasses
+of {DBus::Data::Base}, such as {DBus::Data::Int16} or {DBus::Data::UInt64}.
+
 ##### Variants
 
 If the signature expects a Variant
 (which is the case for all Properties!) then an explicit mechanism is needed.
 
-1. A pair [{DBus::Type}, value] specifies to marshall *value* as
+1. Any {DBus::Data::Base}.
+
+2. A {DBus::Data::Variant} made by {DBus.variant}(signature, value).
+   (Formerly this produced the type+value pair below, now it is just an alias
+   to the Variant constructor.)
+
+3. A pair [{DBus::Type}, value] specifies to marshall *value* as
    that specified type.
    The pair can be produced by {DBus.variant}(signature, value) which
    gives the  same result as [{DBus.type}(signature), value].
@@ -181,13 +190,13 @@ If the signature expects a Variant
 
    `foo_i["Bar"] = DBus.variant("au", [0, 1, 1, 2, 3, 5, 8])`
 
-2. Other values are tried to fit one of these:
+4. Other values are tried to fit one of these:
    Boolean, Double, Array of Variants, Hash of String keyed Variants,
    String, Int32, Int64.
 
-3. **Deprecated:** A pair [String, value], where String is a valid
+5. **Deprecated:** A pair [String, value], where String is a valid
    signature of a single complete type, marshalls value as that
-   type. This will hit you when you rely on method (2) but happen to have
+   type. This will hit you when you rely on method (4) but happen to have
    a particular string value in an array.
 
 ##### Structs

--- a/lib/dbus/data.rb
+++ b/lib/dbus/data.rb
@@ -754,10 +754,9 @@ module DBus
       # Determine the type of *value*
       # @param value [::Object]
       # @return [Type]
+      # @api private
       # See also {PacketMarshaller.make_variant}
       def self.guess_type(value)
-        return value.type if value.is_a?(Data::Base)
-
         sct, = PacketMarshaller.make_variant(value)
         DBus.type(sct)
       end

--- a/lib/dbus/data.rb
+++ b/lib/dbus/data.rb
@@ -751,7 +751,13 @@ module DBus
       # @return [Type]
       attr_reader :member_type
 
+      # Determine the type of *value*
+      # @param value [::Object]
+      # @return [Type]
+      # See also {PacketMarshaller.make_variant}
       def self.guess_type(value)
+        return value.type if value.is_a?(Data::Base)
+
         sct, = PacketMarshaller.make_variant(value)
         DBus.type(sct)
       end

--- a/lib/dbus/data.rb
+++ b/lib/dbus/data.rb
@@ -762,8 +762,9 @@ module DBus
         DBus.type(sct)
       end
 
-      # @param member_type [Type,nil]
+      # @param member_type [SingleCompleteType,Type,nil]
       def initialize(value, member_type:)
+        member_type = Type::Factory.make_type(member_type) if member_type
         # TODO: validate that the given *member_type* matches *value*
         case value
         when Data::Variant
@@ -780,6 +781,30 @@ module DBus
           value = Data.make_typed(@member_type, value)
         end
         super(value)
+      end
+
+      # Internal helpers to keep the {DBus.variant} method working.
+      # Formerly it returned just a pair of [DBus.type(string_type), value]
+      # so let's provide [0], [1], .first, .last
+      def [](index)
+        case index
+        when 0
+          member_type
+        when 1
+          value
+        else
+          raise ArgumentError, "DBus.variant can only be indexed with 0 or 1, seen #{index.inspect}"
+        end
+      end
+
+      # @see #[]
+      def first
+        self[0]
+      end
+
+      # @see #[]
+      def last
+        self[1]
       end
     end
 

--- a/lib/dbus/data.rb
+++ b/lib/dbus/data.rb
@@ -601,8 +601,10 @@ module DBus
 
         typed_value = case value
                       when Data::Array
-                        raise ArgumentError, "Specified type is #{type} but value type is #{value.type}" \
-                          unless value.type == type
+                        unless value.type == type
+                          raise ArgumentError,
+                                "Specified type is #{type.inspect} but value type is #{value.type.inspect}"
+                        end
 
                         value.exact_value
                       else
@@ -651,8 +653,10 @@ module DBus
 
         typed_value = case value
                       when self.class
-                        raise ArgumentError, "Specified type is #{type} but value type is #{value.type}" \
-                          unless value.type == type
+                        unless value.type == type
+                          raise ArgumentError,
+                                "Specified type is #{type.inspect} but value type is #{value.type.inspect}"
+                        end
 
                         value.exact_value
                       else

--- a/lib/dbus/introspect.rb
+++ b/lib/dbus/introspect.rb
@@ -238,19 +238,20 @@ module DBus
   # An (exported) property
   # https://dbus.freedesktop.org/doc/dbus-specification.html#standard-interfaces-properties
   class Property
-    # @return [String] The name of the property, for example FooBar.
+    # @return [Symbol] The name of the property, for example FooBar.
     attr_reader :name
     # @return [SingleCompleteType]
     attr_reader :type
     # @return [Symbol] :read :write or :readwrite
     attr_reader :access
 
-    # @return [Symbol] What to call at Ruby side.
+    # @return [Symbol,nil] What to call at Ruby side.
     #   (Always without the trailing `=`)
+    #   It is `nil` IFF representing a client-side proxy.
     attr_reader :ruby_name
 
     def initialize(name, type, access, ruby_name:)
-      @name = name
+      @name = name.to_sym
       @type = type
       @access = access
       @ruby_name = ruby_name
@@ -269,6 +270,15 @@ module DBus
     # Return introspection XML string representation of the property.
     def to_xml
       "    <property type=\"#{@type}\" name=\"#{@name}\" access=\"#{@access}\"/>\n"
+    end
+
+    # @param xml_node [AbstractXML::Node]
+    # @return [Property]
+    def self.from_xml(xml_node)
+      name = xml_node["name"].to_sym
+      type = xml_node["type"]
+      access = xml_node["access"].to_sym
+      new(name, type, access, ruby_name: nil)
     end
   end
 end

--- a/lib/dbus/proxy_object_factory.rb
+++ b/lib/dbus/proxy_object_factory.rb
@@ -29,11 +29,13 @@ module DBus
     # @param pobj [ProxyObject]
     # @param xml [String]
     def self.introspect_into(pobj, xml)
+      # intfs [Array<Interface>], subnodes [Array<String>]
       intfs, pobj.subnodes = IntrospectXMLParser.new(xml).parse
       intfs.each do |i|
         poi = ProxyObjectInterface.new(pobj, i.name)
         i.methods.each_value { |m| poi.define(m) }
         i.signals.each_value { |s| poi.define(s) }
+        i.properties.each_value { |p| poi.define(p) }
         pobj[i.name] = poi
       end
       pobj.introspected = true

--- a/lib/dbus/proxy_object_interface.rb
+++ b/lib/dbus/proxy_object_interface.rb
@@ -150,10 +150,18 @@ module DBus
               "Property '#{name}.#{property_name}' (on object '#{object.path}') not found"
       end
 
-      type = property.type
-      type = DBus.type(type) unless type.is_a?(Type)
-      typed_value = Data.make_typed(type, value)
-      variant = Data::Variant.new(typed_value, member_type: type)
+      case value
+      # accommodate former need to explicitly make a variant with the right type
+      when Data::Variant
+        variant = value
+      else
+        type = property.type
+        type = DBus.type(type) unless type.is_a?(Type)
+
+        typed_value = Data.make_typed(type, value)
+        variant = Data::Variant.new(typed_value, member_type: type)
+      end
+
       object[PROPERTY_INTERFACE].Set(name, property_name, variant)
     end
 

--- a/lib/dbus/proxy_object_interface.rb
+++ b/lib/dbus/proxy_object_interface.rb
@@ -156,8 +156,6 @@ module DBus
         variant = value
       else
         type = property.type
-        type = DBus.type(type) unless type.is_a?(Type)
-
         typed_value = Data.make_typed(type, value)
         variant = Data::Variant.new(typed_value, member_type: type)
       end

--- a/lib/dbus/type.rb
+++ b/lib/dbus/type.rb
@@ -415,8 +415,9 @@ module DBus
   # @param string_type [SingleCompleteType]
   # @param value [::Object]
   # @return [Array(DBus::Type::Type,::Object)]
+  # @deprecated Use {Data::Variant.new} instead
   def variant(string_type, value)
-    [type(string_type), value]
+    Data::Variant.new(value, member_type: string_type)
   end
   module_function :variant
 end

--- a/lib/dbus/xml.rb
+++ b/lib/dbus/xml.rb
@@ -134,6 +134,10 @@ module DBus
           parse_methsig(se, s)
           i << s
         end
+        e.each("property") do |pe|
+          p = Property.from_xml(pe)
+          i << p
+        end
       end
       d = Time.now - t
       if d > 2

--- a/spec/data_spec.rb
+++ b/spec/data_spec.rb
@@ -632,6 +632,36 @@ describe DBus::Data do
 
       include_examples "#== and #eql? work for container types (1 value)",
                        "/foo", { member_type: DBus.type(T::STRING) }
+
+      describe "DBus.variant compatibility" do
+        let(:v) { DBus.variant("o", "/foo") }
+
+        describe "#[]" do
+          it "returns the type for 0" do
+            expect(v[0]).to eq DBus.type(DBus::Type::OBJECT_PATH)
+          end
+
+          it "returns the value for 1" do
+            expect(v[1]).to eq DBus::ObjectPath.new("/foo")
+          end
+
+          it "returns an error for other indices" do
+            expect { v[2] }.to raise_error(ArgumentError, /DBus.variant can only be indexed with 0 or 1/)
+          end
+        end
+
+        describe "#first" do
+          it "returns the type" do
+            expect(v.first).to eq DBus.type(DBus::Type::OBJECT_PATH)
+          end
+        end
+
+        describe "#last" do
+          it "returns the value" do
+            expect(v.last).to eq DBus::ObjectPath.new("/foo")
+          end
+        end
+      end
     end
   end
 end

--- a/spec/property_spec.rb
+++ b/spec/property_spec.rb
@@ -201,21 +201,32 @@ describe "PropertyTest" do
   end
 
   context "a byte-typed property" do
-    it "gets set with a correct type (#108)" do
-      # Slightly advanced RSpec:
-      # https://rspec.info/documentation/3.9/rspec-expectations/RSpec/Matchers.html#satisfy-instance_method
-      a_byte_in_a_variant = \
-        satisfying { |x| x.is_a?(DBus::Data::Variant) && x.member_type.to_s == DBus::Type::BYTE }
+    # Slightly advanced RSpec:
+    # https://rspec.info/documentation/3.9/rspec-expectations/RSpec/Matchers.html#satisfy-instance_method
+    let(:a_byte_in_a_variant) do
+      satisfying { |x| x.is_a?(DBus::Data::Variant) && x.member_type.to_s == DBus::Type::BYTE }
       # ^ This formatting keeps the matcher on a single line
       # which enables RSpect to cite it if it fails, instead of saying "block".
+    end
 
-      prop_iface = @obj[DBus::PROPERTY_INTERFACE]
+    let(:prop_iface) { @obj[DBus::PROPERTY_INTERFACE] }
+
+    it "gets set with a correct type (#108)" do
       expect(prop_iface).to receive(:Set).with(
         "org.ruby.SampleInterface",
         "MyByte",
         a_byte_in_a_variant
       )
       @iface["MyByte"] = 1
+    end
+
+    it "gets set with a correct type (#108), when using the DBus.variant workaround" do
+      expect(prop_iface).to receive(:Set).with(
+        "org.ruby.SampleInterface",
+        "MyByte",
+        a_byte_in_a_variant
+      )
+      @iface["MyByte"] = DBus.variant("y", 1)
     end
   end
 

--- a/spec/property_spec.rb
+++ b/spec/property_spec.rb
@@ -60,7 +60,7 @@ describe "PropertyTest" do
 
   it "tests get all" do
     all = @iface.all_properties
-    expect(all.keys.sort).to eq(["MyArray", "MyDict", "MyStruct", "MyVariant", "ReadMe", "ReadOrWriteMe"])
+    expect(all.keys.sort).to eq(["MyArray", "MyByte", "MyDict", "MyStruct", "MyVariant", "ReadMe", "ReadOrWriteMe"])
   end
 
   it "tests get all on a V1 object" do
@@ -68,7 +68,7 @@ describe "PropertyTest" do
     iface = obj["org.ruby.SampleInterface"]
 
     all = iface.all_properties
-    expect(all.keys.sort).to eq(["MyArray", "MyDict", "MyStruct", "MyVariant", "ReadMe", "ReadOrWriteMe"])
+    expect(all.keys.sort).to eq(["MyArray", "MyByte", "MyDict", "MyStruct", "MyVariant", "ReadMe", "ReadOrWriteMe"])
   end
 
   it "tests unknown property reading" do
@@ -197,6 +197,25 @@ describe "PropertyTest" do
       iface = obj["org.ruby.SampleInterface"]
       val = iface["MyVariant"]
       expect(val).to eq([42, 43])
+    end
+  end
+
+  context "a byte-typed property" do
+    it "gets set with a correct type (#108)" do
+      # Slightly advanced RSpec:
+      # https://rspec.info/documentation/3.9/rspec-expectations/RSpec/Matchers.html#satisfy-instance_method
+      a_byte_in_a_variant = \
+        satisfying { |x| x.is_a?(DBus::Data::Variant) && x.member_type.to_s == DBus::Type::BYTE }
+      # ^ This formatting keeps the matcher on a single line
+      # which enables RSpect to cite it if it fails, instead of saying "block".
+
+      prop_iface = @obj[DBus::PROPERTY_INTERFACE]
+      expect(prop_iface).to receive(:Set).with(
+        "org.ruby.SampleInterface",
+        "MyByte",
+        a_byte_in_a_variant
+      )
+      @iface["MyByte"] = 1
     end
   end
 

--- a/spec/service_newapi.rb
+++ b/spec/service_newapi.rb
@@ -28,6 +28,8 @@ class Test < DBus::Object
       "three" => [3, 3, 3]
     }
     @my_variant = @my_array.dup
+    # 201 is a RET instruction for ZX Spectrum which has turned 40 recently
+    @my_byte = 201
     @main_loop = nil
   end
 
@@ -111,6 +113,8 @@ class Test < DBus::Object
     dbus_attr_accessor :my_array, "aq"
     dbus_attr_accessor :my_dict, "a{sv}"
     dbus_attr_accessor :my_variant, "v"
+
+    dbus_attr_accessor :my_byte, "y"
   end
 
   # closing and reopening the same interface


### PR DESCRIPTION
The type has always been VARIANT, as required by the method signature, but the type wrapped *inside* was guessed poorly, by
`PacketMarshaller.make_variant`.

Fix it by converting the supplied argument with `Data.make_typed`, using the property type learned by introspection.

Added `ProxyObjectInterface#properties` which were missing until now.