### PR TITLE
Use the correct type for values in PropertiesChanged 

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,16 @@
 
 ## Unreleased
 
+Bug fixes:
+ * Introduced Object#dbus_properties_changed to send correctly typed property
+   values ([#115][]). Avoid calling PropertiesChanged directly as it will
+   guess the types.
+
+API:
+ * Object.dbus_watcher now needs an additional _type_ argument.
+
+[#115]: https://github.com/mvidner/ruby-dbus/issues/115
+
 ## Ruby D-Bus 0.18.0.beta7 - 2022-05-29
 
 API:

--- a/lib/dbus/object.rb
+++ b/lib/dbus/object.rb
@@ -236,7 +236,7 @@ module DBus
       # the argument order is alias_method(new_name, existing_name)
       alias_method original_ruby_name_eq, ruby_name_eq
       define_method ruby_name_eq do |value|
-        public_send(original_ruby_name_eq, value)
+        result = public_send(original_ruby_name_eq, value)
 
         dbus_property_changed4(
           interface_name: interface_name,
@@ -244,6 +244,8 @@ module DBus
           value: value,
           type: type
         )
+
+        result
       end
     end
 

--- a/lib/dbus/object.rb
+++ b/lib/dbus/object.rb
@@ -126,12 +126,13 @@ module DBus
     #
     # Whenever the property value gets changed from "inside" the object,
     # you should emit the `PropertiesChanged` signal by calling
+    # {#dbus_properties_changed}.
     #
-    #   object[DBus::PROPERTY_INTERFACE].PropertiesChanged(interface_name, {dbus_name.to_s => value}, [])
+    #   dbus_properties_changed(interface_name, {dbus_name.to_s => value}, [])
     #
     # or, omitting the value in the signal,
     #
-    #   object[DBus::PROPERTY_INTERFACE].PropertiesChanged(interface_name, {}, [dbus_name.to_s])
+    #   dbus_properties_changed(interface_name, {}, [dbus_name.to_s])
     #
     # @param  (see .dbus_attr_accessor)
     # @return (see .dbus_attr_accessor)
@@ -175,12 +176,13 @@ module DBus
     #
     # Whenever the property value gets changed from "inside" the object,
     # you should emit the `PropertiesChanged` signal by calling
+    # {#dbus_properties_changed}.
     #
-    #   object[DBus::PROPERTY_INTERFACE].PropertiesChanged(interface_name, {dbus_name.to_s => value}, [])
+    #   dbus_properties_changed(interface_name, {dbus_name.to_s => value}, [])
     #
     # or, omitting the value in the signal,
     #
-    #   object[DBus::PROPERTY_INTERFACE].PropertiesChanged(interface_name, {}, [dbus_name.to_s])
+    #   dbus_properties_changed(interface_name, {}, [dbus_name.to_s])
     #
     # @param  (see .dbus_attr_accessor)
     # @return (see .dbus_attr_accessor)
@@ -223,7 +225,7 @@ module DBus
     def self.dbus_watcher(ruby_name, type:, dbus_name: nil)
       raise UndefinedInterface, ruby_name if @@cur_intf.nil?
 
-      cur_intf = @@cur_intf
+      interface_name = @@cur_intf.name
 
       ruby_name = ruby_name.to_s.sub(/=$/, "").to_sym
       ruby_name_eq = "#{ruby_name}=".to_sym
@@ -236,11 +238,12 @@ module DBus
       define_method ruby_name_eq do |value|
         public_send(original_ruby_name_eq, value)
 
-        # TODO: respect EmitsChangedSignal to use invalidated_properties instead
-        # PropertiesChanged, "interface:s, changed_properties:a{sv}, invalidated_properties:as"
-        typed_value = Data.make_typed(type, value)
-        variant = Data::Variant.new(typed_value, member_type: type)
-        PropertiesChanged(cur_intf.name, { dbus_name.to_s => variant }, [])
+        dbus_property_changed4(
+          interface_name: interface_name,
+          dbus_name: dbus_name,
+          value: value,
+          type: type
+        )
       end
     end
 
@@ -302,6 +305,35 @@ module DBus
     def self.make_dbus_name(ruby_name, dbus_name: nil)
       dbus_name ||= camelize(ruby_name.to_s)
       dbus_name.to_sym
+    end
+
+    # Use this instead of calling PropertiesChanged directly. This one
+    # considers not only the PC signature (which says that all property values
+    # are variants) but also the specific property type.
+    # @param interface_name [String] interface name like "org.example.ManagerManager"
+    # @param changed_props [Hash{String => ::Object}]
+    #   changed properties (D-Bus names) and their values.
+    # @param invalidated_props [Array<String>]
+    #   names of properties whose changed value is not specified
+    def dbus_properties_changed(interface_name, changed_props, invalidated_props)
+      typed_changed_props = changed_props.map do |dbus_name, value|
+        property = dbus_lookup_property(interface_name, dbus_name)
+        type = property.type
+        typed_value = Data.make_typed(type, value)
+        variant = Data::Variant.new(typed_value, member_type: type)
+        [dbus_name, variant]
+      end.to_h
+      PropertiesChanged(interface_name, typed_changed_props, invalidated_props)
+    end
+
+    # 4 individual necessary arguments
+    # @api private
+    def dbus_property_changed4(interface_name:, dbus_name:, value:, type:)
+      # TODO: respect EmitsChangedSignal to use invalidated_properties instead
+
+      typed_value = Data.make_typed(type, value)
+      variant = Data::Variant.new(typed_value, member_type: type)
+      PropertiesChanged(interface_name, { dbus_name.to_s => variant }, [])
     end
 
     # @param interface_name [String]

--- a/lib/dbus/type.rb
+++ b/lib/dbus/type.rb
@@ -415,7 +415,7 @@ module DBus
   # @param string_type [SingleCompleteType]
   # @param value [::Object]
   # @return [Array(DBus::Type::Type,::Object)]
-  # @deprecated Use {Data::Variant.new} instead
+  # @deprecated Use {Data::Variant#initialize} instead
   def variant(string_type, value)
     Data::Variant.new(value, member_type: string_type)
   end

--- a/spec/object_spec.rb
+++ b/spec/object_spec.rb
@@ -20,7 +20,7 @@ describe DBus::Object do
       let(:a_struct_in_a_variant) do
         satisfying { |x| x.is_a?(DBus::Data::Variant) && x.member_type.to_s == "(ss)" }
         # ^ This formatting keeps the matcher on a single line
-        # which enables RSpect to cite it if it fails, instead of saying "block".
+        # which enables RSpec to cite it if it fails, instead of saying "block".
       end
 
       it "emits PropertyChanged with correctly typed argument" do

--- a/spec/object_spec.rb
+++ b/spec/object_spec.rb
@@ -1,0 +1,41 @@
+#!/usr/bin/env rspec
+# frozen_string_literal: true
+
+require_relative "spec_helper"
+require "dbus"
+
+class ObjectTest < DBus::Object
+  T = DBus::Type unless const_defined? "T"
+
+  dbus_interface "org.ruby.ServerTest" do
+    dbus_attr_writer :write_me, T::Struct[String, String]
+  end
+end
+
+describe DBus::Object do
+  describe ".dbus_attr_writer" do
+    describe "the declared assignment method" do
+      # Slightly advanced RSpec:
+      # https://rspec.info/documentation/3.9/rspec-expectations/RSpec/Matchers.html#satisfy-instance_method
+      let(:a_struct_in_a_variant) do
+        satisfying { |x| x.is_a?(DBus::Data::Variant) && x.member_type.to_s == "(ss)" }
+        # ^ This formatting keeps the matcher on a single line
+        # which enables RSpect to cite it if it fails, instead of saying "block".
+      end
+
+      it "emits PropertyChanged with correctly typed argument" do
+        obj = ObjectTest.new("/test")
+        expect(obj).to receive(:PropertiesChanged).with(
+          "org.ruby.ServerTest",
+          {
+            "WriteMe" => a_struct_in_a_variant
+          },
+          []
+        )
+        # bug: call PC with simply the assigned value,
+        # which will need type guessing
+        obj.write_me = ["two", "strings"]
+      end
+    end
+  end
+end

--- a/spec/property_spec.rb
+++ b/spec/property_spec.rb
@@ -110,6 +110,7 @@ describe "PropertyTest" do
     end
 
     @iface["ReadOrWriteMe"] = "VALUE"
+    @iface.SetTwoProperties("REAMDE", 255)
 
     # loop to process the signal. complicated :-( see signal_spec.rb
     loop = DBus::Main.new
@@ -123,6 +124,8 @@ describe "PropertyTest" do
     quitter.join
 
     expect(received["ReadOrWriteMe"]).to eq("VALUE")
+    expect(received["ReadMe"]).to eq("REAMDE")
+    expect(received["MyByte"]).to eq(255)
   end
 
   context "a struct-typed property" do

--- a/spec/property_spec.rb
+++ b/spec/property_spec.rb
@@ -209,7 +209,7 @@ describe "PropertyTest" do
     let(:a_byte_in_a_variant) do
       satisfying { |x| x.is_a?(DBus::Data::Variant) && x.member_type.to_s == DBus::Type::BYTE }
       # ^ This formatting keeps the matcher on a single line
-      # which enables RSpect to cite it if it fails, instead of saying "block".
+      # which enables RSpec to cite it if it fails, instead of saying "block".
     end
 
     let(:prop_iface) { @obj[DBus::PROPERTY_INTERFACE] }

--- a/spec/service_newapi.rb
+++ b/spec/service_newapi.rb
@@ -115,6 +115,15 @@ class Test < DBus::Object
     dbus_attr_accessor :my_variant, "v"
 
     dbus_attr_accessor :my_byte, "y"
+
+    # to test dbus_properties_changed
+    dbus_method :SetTwoProperties, "in read_me:s, in byte:y" do |read_me, byte|
+      @read_me = read_me
+      @my_byte = byte
+      dbus_properties_changed(INTERFACE,
+                              { "ReadMe" => read_me, "MyByte" => byte },
+                              [])
+    end
   end
 
   # closing and reopening the same interface


### PR DESCRIPTION
To fix #115

- [x] NEWS.md, and mention how dbus_watcher changes
- [x] test, probably similarly to property_spec in #113