### PR TITLE
Authentication: allow authentication with containers; refactor and test it all.

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -17,7 +17,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby-version: ['2.5', '2.6', '2.7', '3.0', '3.1', 'head']
+        # Adding a new one? Change it in Coveralls below!
+        ruby-version: ['2.5', '2.6', '2.7', '3.0', '3.1', '3.2', 'head']
 
     steps:
     - uses: actions/checkout@v2
@@ -36,7 +37,7 @@ jobs:
 
     - name: Coveralls Report
       # send it only for the latest version to avoid duplicate submits
-      if: ${{ matrix.ruby-version == '3.1' }}
+      if: ${{ matrix.ruby-version == '3.2' }}
       uses: coverallsapp/github-action@master
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+Features:
+ * For EXTERNAL authentication, try also without the user id, to work with
+   containers ([#126][]).
+
+[#126]: https://github.com/mvidner/ruby-dbus/issues/126
+
 ## Ruby D-Bus 0.19.0 - 2023-01-18
 
 API:

--- a/examples/simple/get_id.rb
+++ b/examples/simple/get_id.rb
@@ -6,7 +6,9 @@ $LOAD_PATH.unshift File.expand_path("../../lib", __dir__)
 
 require "dbus"
 
-bus = DBus::SystemBus.instance
+busname = ARGV.fetch(0, "system")
+bus = busname == "session" ? DBus::SessionBus.instance : DBus::SystemBus.instance
+
 driver_svc = bus["org.freedesktop.DBus"]
 # p driver_svc
 driver_obj = driver_svc["/"]
@@ -15,4 +17,4 @@ driver_ifc = driver_obj["org.freedesktop.DBus"]
 # p driver_ifc
 
 bus_id = driver_ifc.GetId
-puts "The system bus id is #{bus_id}"
+puts "The #{busname} bus id is #{bus_id}"

--- a/lib/dbus/auth.rb
+++ b/lib/dbus/auth.rb
@@ -127,10 +127,15 @@ module DBus
       # NOTE: not implemented yet in upper layers
       attr_reader :unix_fd
 
+      # @return [String]
+      attr_reader :address_uuid
+
       # Create a new authentication client.
       # @param mechs [Array<Mechanism,Class>,nil] custom list of auth Mechanism objects or classes
       def initialize(socket, mechs = nil)
         @unix_fd = false
+        @address_uuid = nil
+
         @socket = socket
         @state = nil
         @auth_list = mechs || [

--- a/lib/dbus/auth.rb
+++ b/lib/dbus/auth.rb
@@ -12,261 +12,267 @@ require "rbconfig"
 
 module DBus
   # Exception raised when authentication fails somehow.
-  class AuthenticationFailed < Exception
+  class AuthenticationFailed < StandardError
   end
 
-  # = General class for authentication.
-  class Authenticator
-    # Returns the name of the authenticator.
-    def name
-      self.class.to_s.upcase.sub(/.*::/, "")
-    end
-  end
-
-  # = Anonymous authentication class
-  class Anonymous < Authenticator
-    def authenticate
-      "527562792044427573" # Hex encoded version of "Ruby DBus"
-    end
-  end
-
-  # = External authentication class
+  # The Authentication Protocol.
+  # https://dbus.freedesktop.org/doc/dbus-specification.html#auth-protocol
   #
-  # Class for 'external' type authentication.
-  class External < Authenticator
-    # Performs the authentication.
-    def authenticate
-      # Take the user id (eg integer 1000) make a string out of it "1000", take
-      # each character and determin hex value "1" => 0x31, "0" => 0x30. You
-      # obtain for "1000" => 31303030 This is what the server is expecting.
-      # Why? I dunno. How did I come to that conclusion? by looking at rbus
-      # code. I have no idea how he found that out.
-      Process.uid.to_s.split(//).map { |d| d.ord.to_s(16) }.join
-    end
-  end
-
-  # = Authentication class using SHA1 crypto algorithm
-  #
-  # Class for 'CookieSHA1' type authentication.
-  # Implements the AUTH DBUS_COOKIE_SHA1 mechanism.
-  class DBusCookieSHA1 < Authenticator
-    # the autenticate method (called in stage one of authentification)
-    def authenticate
-      require "etc"
-      # number of retries we have for auth
-      @retries = 1
-      hex_encode(Etc.getlogin).to_s # server expects it to be binary
+  # @api private
+  module Authentication
+    # = General class for authentication.
+    class Authenticator
+      # Returns the name of the authenticator.
+      def name
+        self.class.to_s.upcase.sub(/.*::/, "")
+      end
     end
 
-    # returns the modules name
-    def name
-      "DBUS_COOKIE_SHA1"
+    # = Anonymous authentication class
+    class Anonymous < Authenticator
+      def authenticate
+        "527562792044427573" # Hex encoded version of "Ruby DBus"
+      end
     end
 
-    # handles the interesting crypto stuff, check the rbus-project for more info: http://rbus.rubyforge.org/
-    def data(hexdata)
-      require "digest/sha1"
-      data = hex_decode(hexdata)
-      # name of cookie file, id of cookie in file, servers random challenge
-      context, id, s_challenge = data.split(" ")
-      # Random client challenge
-      c_challenge = 1.upto(s_challenge.bytesize / 2).map { rand(255).to_s }.join
-      # Search cookie file for id
-      path = File.join(ENV["HOME"], ".dbus-keyrings", context)
-      DBus.logger.debug "path: #{path.inspect}"
-      File.foreach(path) do |line|
-        if line.start_with?(id)
-          # Right line of file, read cookie
-          cookie = line.split(" ")[2].chomp
-          DBus.logger.debug "cookie: #{cookie.inspect}"
-          # Concatenate and encrypt
-          to_encrypt = [s_challenge, c_challenge, cookie].join(":")
-          sha = Digest::SHA1.hexdigest(to_encrypt)
-          # the almighty tcp server wants everything hex encoded
-          hex_response = hex_encode("#{c_challenge} #{sha}")
-          # Return response
-          response = [:AuthOk, hex_response]
-          return response
+    # = External authentication class
+    #
+    # Class for 'external' type authentication.
+    class External < Authenticator
+      # Performs the authentication.
+      def authenticate
+        # Take the user id (eg integer 1000) make a string out of it "1000", take
+        # each character and determin hex value "1" => 0x31, "0" => 0x30. You
+        # obtain for "1000" => 31303030 This is what the server is expecting.
+        # Why? I dunno. How did I come to that conclusion? by looking at rbus
+        # code. I have no idea how he found that out.
+        Process.uid.to_s.split(//).map { |d| d.ord.to_s(16) }.join
+      end
+    end
+
+    # = Authentication class using SHA1 crypto algorithm
+    #
+    # Class for 'CookieSHA1' type authentication.
+    # Implements the AUTH DBUS_COOKIE_SHA1 mechanism.
+    class DBusCookieSHA1 < Authenticator
+      # the autenticate method (called in stage one of authentification)
+      def authenticate
+        require "etc"
+        # number of retries we have for auth
+        @retries = 1
+        hex_encode(Etc.getlogin).to_s # server expects it to be binary
+      end
+
+      # returns the modules name
+      def name
+        "DBUS_COOKIE_SHA1"
+      end
+
+      # handles the interesting crypto stuff, check the rbus-project for more info: http://rbus.rubyforge.org/
+      def data(hexdata)
+        require "digest/sha1"
+        data = hex_decode(hexdata)
+        # name of cookie file, id of cookie in file, servers random challenge
+        context, id, s_challenge = data.split(" ")
+        # Random client challenge
+        c_challenge = 1.upto(s_challenge.bytesize / 2).map { rand(255).to_s }.join
+        # Search cookie file for id
+        path = File.join(ENV["HOME"], ".dbus-keyrings", context)
+        DBus.logger.debug "path: #{path.inspect}"
+        File.foreach(path) do |line|
+          if line.start_with?(id)
+            # Right line of file, read cookie
+            cookie = line.split(" ")[2].chomp
+            DBus.logger.debug "cookie: #{cookie.inspect}"
+            # Concatenate and encrypt
+            to_encrypt = [s_challenge, c_challenge, cookie].join(":")
+            sha = Digest::SHA1.hexdigest(to_encrypt)
+            # the almighty tcp server wants everything hex encoded
+            hex_response = hex_encode("#{c_challenge} #{sha}")
+            # Return response
+            response = [:AuthOk, hex_response]
+            return response
+          end
         end
+        return if @retries <= 0
+
+        # a little rescue magic
+        puts "ERROR: Could not auth, will now exit."
+        puts "ERROR: Unable to locate cookie, retry in 1 second."
+        @retries -= 1
+        sleep 1
+        data(hexdata)
       end
-      return if @retries <= 0
 
-      # a little rescue magic
-      puts "ERROR: Could not auth, will now exit."
-      puts "ERROR: Unable to locate cookie, retry in 1 second."
-      @retries -= 1
-      sleep 1
-      data(hexdata)
-    end
+      # encode plain to hex
+      def hex_encode(plain)
+        return nil if plain.nil?
 
-    # encode plain to hex
-    def hex_encode(plain)
-      return nil if plain.nil?
-
-      plain.to_s.unpack1("H*")
-    end
-
-    # decode hex to plain
-    def hex_decode(encoded)
-      encoded.scan(/[[:xdigit:]]{2}/).map { |h| h.hex.chr }.join
-    end
-  end
-
-  # Note: this following stuff is tested with External authenticator only!
-
-  # = Authentication client class.
-  #
-  # Class tha performs the actional authentication.
-  class Client
-    # Create a new authentication client.
-    def initialize(socket)
-      @socket = socket
-      @state = nil
-      @auth_list = [External, DBusCookieSHA1, Anonymous]
-    end
-
-    # Start the authentication process.
-    def authenticate
-      if RbConfig::CONFIG["target_os"] =~ /freebsd/
-        @socket.sendmsg(0.chr, 0, nil, [:SOCKET, :SCM_CREDS, ""])
-      else
-        @socket.write(0.chr)
+        plain.to_s.unpack1("H*")
       end
-      next_authenticator
-      @state = :Starting
-      while @state != :Authenticated
-        r = next_state
-        return r if !r
+
+      # decode hex to plain
+      def hex_decode(encoded)
+        encoded.scan(/[[:xdigit:]]{2}/).map { |h| h.hex.chr }.join
       end
-      true
     end
 
-    ##########
+    # Note: this following stuff is tested with External authenticator only!
 
-    private
-
-    ##########
-
-    # Send an authentication method _meth_ with arguments _args_ to the
-    # server.
-    def send(meth, *args)
-      o = ([meth] + args).join(" ")
-      @socket.write("#{o}\r\n")
-    end
-
-    # Try authentication using the next authenticator.
-    def next_authenticator
-      raise AuthenticationFailed if @auth_list.empty?
-
-      @authenticator = @auth_list.shift.new
-      auth_msg = ["AUTH", @authenticator.name, @authenticator.authenticate]
-      DBus.logger.debug "auth_msg: #{auth_msg.inspect}"
-      send(auth_msg)
-    rescue AuthenticationFailed
-      @socket.close
-      raise
-    end
-
-    # Read data (a buffer) from the bus until CR LF is encountered.
-    # Return the buffer without the CR LF characters.
-    def next_msg
-      data = ""
-      crlf = "\r\n"
-      left = 1024 # 1024 byte, no idea if it's ever getting bigger
-      while left.positive?
-        buf = @socket.read(left > 1 ? 1 : left)
-        break if buf.nil?
-
-        left -= buf.bytesize
-        data += buf
-        break if data.include? crlf # crlf means line finished, the TCP socket keeps on listening, so we break
+    # = Authentication client class.
+    #
+    # Class tha performs the actional authentication.
+    class Client
+      # Create a new authentication client.
+      def initialize(socket)
+        @socket = socket
+        @state = nil
+        @auth_list = [External, DBusCookieSHA1, Anonymous]
       end
-      readline = data.chomp.split(" ")
-      DBus.logger.debug "readline: #{readline.inspect}"
-      readline
-    end
 
-    #     # Read data (a buffer) from the bus until CR LF is encountered.
-    #     # Return the buffer without the CR LF characters.
-    #     def next_msg
-    #       @socket.readline.chomp.split(" ")
-    #     end
-
-    # Try to reach the next state based on the current state.
-    def next_state
-      msg = next_msg
-      if @state == :Starting
-        DBus.logger.debug ":Starting msg: #{msg[0].inspect}"
-        case msg[0]
-        when "OK"
-          @state = :WaitingForOk
-        when "CONTINUE"
-          @state = :WaitingForData
-        when "REJECTED" # needed by tcp, unix-path/abstract doesn't get here
-          @state = :WaitingForData
+      # Start the authentication process.
+      def authenticate
+        if RbConfig::CONFIG["target_os"] =~ /freebsd/
+          @socket.sendmsg(0.chr, 0, nil, [:SOCKET, :SCM_CREDS, ""])
+        else
+          @socket.write(0.chr)
         end
+        next_authenticator
+        @state = :Starting
+        while @state != :Authenticated
+          r = next_state
+          return r if !r
+        end
+        true
       end
-      DBus.logger.debug "state: #{@state}"
-      case @state
-      when :WaitingForData
-        DBus.logger.debug ":WaitingForData msg: #{msg[0].inspect}"
-        case msg[0]
-        when "DATA"
-          chall = msg[1]
-          resp, chall = @authenticator.data(chall)
-          DBus.logger.debug ":WaitingForData/DATA resp: #{resp.inspect}"
-          case resp
-          when :AuthContinue
-            send("DATA", chall)
-            @state = :WaitingForData
-          when :AuthOk
-            send("DATA", chall)
+
+      ##########
+
+      private
+
+      ##########
+
+      # Send an authentication method _meth_ with arguments _args_ to the
+      # server.
+      def send(meth, *args)
+        o = ([meth] + args).join(" ")
+        @socket.write("#{o}\r\n")
+      end
+
+      # Try authentication using the next authenticator.
+      def next_authenticator
+        raise AuthenticationFailed if @auth_list.empty?
+
+        @authenticator = @auth_list.shift.new
+        auth_msg = ["AUTH", @authenticator.name, @authenticator.authenticate]
+        DBus.logger.debug "auth_msg: #{auth_msg.inspect}"
+        send(auth_msg)
+      rescue AuthenticationFailed
+        @socket.close
+        raise
+      end
+
+      # Read data (a buffer) from the bus until CR LF is encountered.
+      # Return the buffer without the CR LF characters.
+      def next_msg
+        data = ""
+        crlf = "\r\n"
+        left = 1024 # 1024 byte, no idea if it's ever getting bigger
+        while left.positive?
+          buf = @socket.read(left > 1 ? 1 : left)
+          break if buf.nil?
+
+          left -= buf.bytesize
+          data += buf
+          break if data.include? crlf # crlf means line finished, the TCP socket keeps on listening, so we break
+        end
+        readline = data.chomp.split(" ")
+        DBus.logger.debug "readline: #{readline.inspect}"
+        readline
+      end
+
+      #     # Read data (a buffer) from the bus until CR LF is encountered.
+      #     # Return the buffer without the CR LF characters.
+      #     def next_msg
+      #       @socket.readline.chomp.split(" ")
+      #     end
+
+      # Try to reach the next state based on the current state.
+      def next_state
+        msg = next_msg
+        if @state == :Starting
+          DBus.logger.debug ":Starting msg: #{msg[0].inspect}"
+          case msg[0]
+          when "OK"
             @state = :WaitingForOk
-          when :AuthError
+          when "CONTINUE"
+            @state = :WaitingForData
+          when "REJECTED" # needed by tcp, unix-path/abstract doesn't get here
+            @state = :WaitingForData
+          end
+        end
+        DBus.logger.debug "state: #{@state}"
+        case @state
+        when :WaitingForData
+          DBus.logger.debug ":WaitingForData msg: #{msg[0].inspect}"
+          case msg[0]
+          when "DATA"
+            chall = msg[1]
+            resp, chall = @authenticator.data(chall)
+            DBus.logger.debug ":WaitingForData/DATA resp: #{resp.inspect}"
+            case resp
+            when :AuthContinue
+              send("DATA", chall)
+              @state = :WaitingForData
+            when :AuthOk
+              send("DATA", chall)
+              @state = :WaitingForOk
+            when :AuthError
+              send("ERROR")
+              @state = :WaitingForData
+            end
+          when "REJECTED"
+            next_authenticator
+            @state = :WaitingForData
+          when "ERROR"
+            send("CANCEL")
+            @state = :WaitingForReject
+          when "OK"
+            send("BEGIN")
+            @state = :Authenticated
+          else
             send("ERROR")
             @state = :WaitingForData
           end
-        when "REJECTED"
-          next_authenticator
-          @state = :WaitingForData
-        when "ERROR"
-          send("CANCEL")
-          @state = :WaitingForReject
-        when "OK"
-          send("BEGIN")
-          @state = :Authenticated
-        else
-          send("ERROR")
-          @state = :WaitingForData
+        when :WaitingForOk
+          DBus.logger.debug ":WaitingForOk msg: #{msg[0].inspect}"
+          case msg[0]
+          when "OK"
+            send("BEGIN")
+            @state = :Authenticated
+          when "REJECT"
+            next_authenticator
+            @state = :WaitingForData
+          when "DATA", "ERROR"
+            send("CANCEL")
+            @state = :WaitingForReject
+          else
+            send("ERROR")
+            @state = :WaitingForOk
+          end
+        when :WaitingForReject
+          DBus.logger.debug ":WaitingForReject msg: #{msg[0].inspect}"
+          case msg[0]
+          when "REJECT"
+            next_authenticator
+            @state = :WaitingForOk
+          else
+            @socket.close
+            return false
+          end
         end
-      when :WaitingForOk
-        DBus.logger.debug ":WaitingForOk msg: #{msg[0].inspect}"
-        case msg[0]
-        when "OK"
-          send("BEGIN")
-          @state = :Authenticated
-        when "REJECT"
-          next_authenticator
-          @state = :WaitingForData
-        when "DATA", "ERROR"
-          send("CANCEL")
-          @state = :WaitingForReject
-        else
-          send("ERROR")
-          @state = :WaitingForOk
-        end
-      when :WaitingForReject
-        DBus.logger.debug ":WaitingForReject msg: #{msg[0].inspect}"
-        case msg[0]
-        when "REJECT"
-          next_authenticator
-          @state = :WaitingForOk
-        else
-          @socket.close
-          return false
-        end
+        true
       end
-      true
     end
   end
 end

--- a/lib/dbus/message_queue.rb
+++ b/lib/dbus/message_queue.rb
@@ -19,6 +19,7 @@ module DBus
     attr_reader :socket
 
     def initialize(address)
+      DBus.logger.debug "MessageQueue: #{address}"
       @address = address
       @buffer = ""
       @is_tcp = false

--- a/lib/dbus/message_queue.rb
+++ b/lib/dbus/message_queue.rb
@@ -129,7 +129,7 @@ module DBus
 
     # Initialize the connection to the bus.
     def init_connection
-      client = Client.new(@socket)
+      client = Authentication::Client.new(@socket)
       client.authenticate
     end
 

--- a/spec/auth_spec.rb
+++ b/spec/auth_spec.rb
@@ -46,7 +46,7 @@ describe DBus::Authentication::Client do
   context "with EXTERNAL" do
     let(:subject) { described_class.new(socket, [DBus::Authentication::External]) }
 
-    it "authentication passes" do
+    it "authentication passes, and address_uuid is set" do
       expect_protocol [
         ["AUTH EXTERNAL 393939\r\n", "OK ffffffffffffffffffffffffffffffff\r\n"],
         ["NEGOTIATE_UNIX_FD\r\n", "AGREE_UNIX_FD\r\n"],
@@ -54,6 +54,7 @@ describe DBus::Authentication::Client do
       ]
 
       expect { subject.authenticate }.to_not raise_error
+      expect(subject.address_uuid).to eq "ffffffffffffffffffffffffffffffff"
     end
 
     context "when the server says superfluous things before an OK" do

--- a/spec/auth_spec.rb
+++ b/spec/auth_spec.rb
@@ -28,6 +28,7 @@ describe DBus::Authentication::Client do
     it "authentication passes" do
       expect_protocol [
         ["AUTH ANONYMOUS 527562792044427573\r\n", "OK ffffffffffffffffffffffffffffffff\r\n"],
+        ["NEGOTIATE_UNIX_FD\r\n", "ERROR not for anonymous\r\n"],
         ["BEGIN\r\n"]
       ]
 
@@ -41,10 +42,69 @@ describe DBus::Authentication::Client do
     it "authentication passes" do
       expect_protocol [
         ["AUTH EXTERNAL 393939\r\n", "OK ffffffffffffffffffffffffffffffff\r\n"],
+        ["NEGOTIATE_UNIX_FD\r\n", "AGREE_UNIX_FD\r\n"],
         ["BEGIN\r\n"]
       ]
 
       expect { subject.authenticate }.to_not raise_error
+    end
+
+    context "when the server says superfluous things before an OK" do
+      it "authentication passes" do
+        expect_protocol [
+          ["AUTH EXTERNAL 393939\r\n", "WOULD_YOU_LIKE_SOME_TEA\r\n"],
+          ["ERROR\r\n", "OK ffffffffffffffffffffffffffffffff\r\n"],
+          ["NEGOTIATE_UNIX_FD\r\n", "AGREE_UNIX_FD\r\n"],
+          ["BEGIN\r\n"]
+        ]
+
+        expect { subject.authenticate }.to_not raise_error
+      end
+    end
+
+    context "when the server replies with ERROR" do
+      it "authentication fails orderly" do
+        expect_protocol [
+          ["AUTH EXTERNAL 393939\r\n", "ERROR something failed\r\n"],
+          ["CANCEL\r\n", "REJECTED DBUS_COOKIE_SHA1\r\n"]
+        ]
+
+        allow(socket).to receive(:close) # want to get rid of this
+        # TODO: quote the server error message?
+        expect { subject.authenticate }.to raise_error(DBus::AuthenticationFailed, /exhausted/)
+      end
+    end
+  end
+
+  context "with a  mechanism returning :MechError" do
+    let(:fallible_mechanism) do
+      double(name: "FALLIBLE", call: [:MechError, "not my best day"])
+    end
+
+    let(:subject) { described_class.new(socket, [fallible_mechanism]) }
+
+    it "authentication fails orderly" do
+      expect_protocol [
+        ["ERROR not my best day\r\n", "REJECTED DBUS_COOKIE_SHA1\r\n"]
+      ]
+
+      allow(socket).to receive(:close) # want to get rid of thise
+      expect { subject.authenticate }.to raise_error(DBus::AuthenticationFailed, /exhausted/)
+    end
+  end
+
+  context "with a badly implemented mechanism" do
+    let(:buggy_mechanism) do
+      double(name: "buggy", call: [:smurf, nil])
+    end
+
+    let(:subject) { described_class.new(socket, [buggy_mechanism]) }
+
+    it "authentication fails before protoxol is exchanged" do
+      expect(subject).to_not receive(:write_line)
+      expect(subject).to_not receive(:read_line)
+
+      expect { subject.authenticate }.to raise_error(DBus::AuthenticationFailed, /smurf/)
     end
   end
 end

--- a/spec/auth_spec.rb
+++ b/spec/auth_spec.rb
@@ -13,6 +13,13 @@ describe DBus::Authentication::Client do
     allow(subject).to receive(:send_nul_byte)
   end
 
+  describe "#next_state" do
+    it "raises when I forget to handle a state" do
+      subject.instance_variable_set(:@state, :Denmark)
+      expect { subject.__send__(:next_state, []) }.to raise_error(RuntimeError, /unhandled state :Denmark/)
+    end
+  end
+
   def expect_protocol(pairs)
     pairs.each do |we_say, server_says|
       expect(subject).to receive(:write_line).with(we_say)
@@ -62,6 +69,19 @@ describe DBus::Authentication::Client do
       end
     end
 
+    context "when the server messes up NEGOTIATE_UNIX_FD" do
+      it "authentication fails orderly" do
+        expect_protocol [
+          ["AUTH EXTERNAL 393939\r\n", "OK ffffffffffffffffffffffffffffffff\r\n"],
+          ["NEGOTIATE_UNIX_FD\r\n", "I_DONT_NEGOTIATE_WITH_TENORISTS\r\n"]
+        ]
+
+        allow(socket).to receive(:close) # want to get rid of this
+        # TODO: quote the server error message?
+        expect { subject.authenticate }.to raise_error(DBus::AuthenticationFailed, /Unknown server reply/)
+      end
+    end
+
     context "when the server replies with ERROR" do
       it "authentication fails orderly" do
         expect_protocol [
@@ -76,7 +96,81 @@ describe DBus::Authentication::Client do
     end
   end
 
-  context "with a  mechanism returning :MechError" do
+  context "with a rejected mechanism and then EXTERNAL" do
+    let(:rejected_mechanism) do
+      double("Mechanism", name: "WIMP", call: [:MechContinue, "I expect to be rejected"])
+    end
+
+    let(:subject) { described_class.new(socket, [rejected_mechanism, DBus::Authentication::External]) }
+
+    it "authentication eventually passes" do
+      expect_protocol [
+        [/^AUTH WIMP .*\r\n/, "REJECTED EXTERNAL\r\n"],
+        ["AUTH EXTERNAL 393939\r\n", "OK ffffffffffffffffffffffffffffffff\r\n"],
+        ["NEGOTIATE_UNIX_FD\r\n", "AGREE_UNIX_FD\r\n"],
+        ["BEGIN\r\n"]
+      ]
+
+      expect { subject.authenticate }.to_not raise_error
+    end
+  end
+
+  context "with a DATA-using mechanism" do
+    let(:mechanism) do
+      double("Mechanism", name: "CHALLENGE_ME", call: [:MechContinue, "1"])
+    end
+
+    # try it twice to test calling #use_next_mechanism
+    let(:subject) { described_class.new(socket, [mechanism, mechanism]) }
+
+    it "authentication fails orderly when the server says ERROR" do
+      expect_protocol [
+        ["AUTH CHALLENGE_ME 31\r\n", "ERROR something failed\r\n"],
+        ["CANCEL\r\n", "REJECTED DBUS_COOKIE_SHA1\r\n"],
+        ["AUTH CHALLENGE_ME 31\r\n", "ERROR something failed\r\n"],
+        ["CANCEL\r\n", "REJECTED DBUS_COOKIE_SHA1\r\n"]
+      ]
+
+      allow(socket).to receive(:close) # want to get rid of this
+      # TODO: quote the server error message?
+      expect { subject.authenticate }.to raise_error(DBus::AuthenticationFailed, /exhausted/)
+    end
+
+    it "authentication fails orderly when the server says ERROR and then changes its mind" do
+      expect_protocol [
+        ["AUTH CHALLENGE_ME 31\r\n", "ERROR something failed\r\n"],
+        ["CANCEL\r\n", "I_CHANGED_MY_MIND please come back\r\n"]
+      ]
+
+      allow(socket).to receive(:close) # want to get rid of this
+      # TODO: quote the server error message?
+      expect { subject.authenticate }.to raise_error(DBus::AuthenticationFailed, /Unknown.*MIND.*REJECTED/)
+    end
+
+    it "authentication passes when the server says superfluous things before DATA" do
+      expect_protocol [
+        ["AUTH CHALLENGE_ME 31\r\n", "WOULD_YOU_LIKE_SOME_TEA\r\n"],
+        ["ERROR\r\n", "DATA\r\n"],
+        ["DATA 31\r\n", "OK ffffffffffffffffffffffffffffffff\r\n"],
+        ["NEGOTIATE_UNIX_FD\r\n", "AGREE_UNIX_FD\r\n"],
+        ["BEGIN\r\n"]
+      ]
+
+      expect { subject.authenticate }.to_not raise_error
+    end
+
+    it "authentication passes when the server decides not to need the DATA" do
+      expect_protocol [
+        ["AUTH CHALLENGE_ME 31\r\n", "OK ffffffffffffffffffffffffffffffff\r\n"],
+        ["NEGOTIATE_UNIX_FD\r\n", "AGREE_UNIX_FD\r\n"],
+        ["BEGIN\r\n"]
+      ]
+
+      expect { subject.authenticate }.to_not raise_error
+    end
+  end
+
+  context "with a mechanism returning :MechError" do
     let(:fallible_mechanism) do
       double(name: "FALLIBLE", call: [:MechError, "not my best day"])
     end

--- a/spec/auth_spec.rb
+++ b/spec/auth_spec.rb
@@ -1,0 +1,50 @@
+#!/usr/bin/env rspec
+# frozen_string_literal: true
+
+require_relative "spec_helper"
+require "dbus"
+
+describe DBus::Authentication::Client do
+  let(:socket) { instance_double("Socket") }
+  let(:subject) { described_class.new(socket) }
+
+  before(:each) do
+    allow(Process).to receive(:uid).and_return(999)
+    allow(subject).to receive(:send_nul_byte)
+  end
+
+  def expect_protocol(pairs)
+    pairs.each do |we_say, server_says|
+      expect(subject).to receive(:write_line).with(we_say)
+      next if server_says.nil?
+
+      expect(subject).to receive(:read_line).and_return(server_says)
+    end
+  end
+
+  context "with ANONYMOUS" do
+    let(:subject) { described_class.new(socket, [DBus::Authentication::Anonymous]) }
+
+    it "authentication passes" do
+      expect_protocol [
+        ["AUTH ANONYMOUS 527562792044427573\r\n", "OK ffffffffffffffffffffffffffffffff\r\n"],
+        ["BEGIN\r\n"]
+      ]
+
+      expect { subject.authenticate }.to_not raise_error
+    end
+  end
+
+  context "with EXTERNAL" do
+    let(:subject) { described_class.new(socket, [DBus::Authentication::External]) }
+
+    it "authentication passes" do
+      expect_protocol [
+        ["AUTH EXTERNAL 393939\r\n", "OK ffffffffffffffffffffffffffffffff\r\n"],
+        ["BEGIN\r\n"]
+      ]
+
+      expect { subject.authenticate }.to_not raise_error
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -31,7 +31,7 @@ if coverage
       c.single_report_path = "coverage/lcov.info"
     end
 
-    SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter[
+    SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter.new [
       SimpleCov::Formatter::HTMLFormatter,
       SimpleCov::Formatter::LcovFormatter
     ]

--- a/spec/tools/dbus-limited-session.conf
+++ b/spec/tools/dbus-limited-session.conf
@@ -7,6 +7,20 @@
   <!-- Our well-known bus type, don't change this -->
   <type>session</type>
 
+  <!-- Authentication:
+       This was useful during refactoring, but meanwhile RSpec mocking has
+       replaced it. -->
+  <!-- Explicitly list all known authentication mechanisms,
+       their order is not important.
+       By default the daemon allows all but this lets me disable some. -->
+  <auth>EXTERNAL</auth>
+  <auth>DBUS_COOKIE_SHA1</auth>
+  <auth>ANONYMOUS</auth>
+  <!-- Insecure, other users could call us and exploit debug APIs/bugs -->
+  <!--
+  <allow_anonymous/>
+  -->
+
   <listen>unix:tmpdir=/tmp</listen>
   <listen>tcp:host=127.0.0.1</listen>
 


### PR DESCRIPTION
Authenticating across containers, like `busctl` can do, should work now (#126).

To be able to do that, I had to understand the protocol, which had been a messy black box for me.

Added tests, covering almost all of `auth.rb` (leaving out the parts that I want to replace/fix next).

When reviewing, the `auth.rb` diff is almost meaningless, even when ignoring whitespace, and I suggest to just read the nev version.