### PR TITLE
Signal thread safety: Add a mutex to MessageQueue#push,pop

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,7 @@
 Features:
  * For EXTERNAL authentication, try also without the user id, to work with
    containers ([#126][]).
+ * Thread safety, as long as the non-main threads only send signals.
 
 [#126]: https://github.com/mvidner/ruby-dbus/issues/126
 


### PR DESCRIPTION
Triggered by https://github.com/yast/d-installer/pull/476

The previous attempt at thread safety failed (https://github.com/mvidner/ruby-dbus/issues/7, https://github.com/mvidner/ruby-dbus/issues/73) but now I see a limited use case:

A worker thread only uses the shared bus connection to send signals about its progress and completion. No method calls are accepted there.

That is, we only race for the bus connection in MessageQueue#push, not in the #pop reading part.