### PR TITLE
Reduce socket buffer allocations

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+Bug fixes:
+ * Reduce socket buffer allocations ([#129][]).
+
+[#129]: https://github.com/mvidner/ruby-dbus/pull/129
+
 ## Ruby D-Bus 0.20.0 - 2023-03-21
 
 Features:

--- a/NEWS.md
+++ b/NEWS.md
@@ -87,7 +87,7 @@ API:
    when declaring properties ([#117][]).
 
 [#115]: https://github.com/mvidner/ruby-dbus/issues/115
-[#117]: https://github.com/mvidner/ruby-dbus/pulls/117
+[#117]: https://github.com/mvidner/ruby-dbus/pull/117
 
 ## Ruby D-Bus 0.18.0.beta7 - 2022-05-29
 
@@ -455,7 +455,7 @@ Bug fixes:
  * Handle more ways which tell us that a bus connection has died.
 
 [#3]: https://github.com/mvidner/ruby-dbus/issue/3
-[bsc#617350]: https://bugzilla.novell.com/show_bug.cgi?id=617350
+[bsc#617350]: https://bugzilla.suse.com/show_bug.cgi?id=617350
 
 ## Ruby D-Bus 0.3.0 - 2010-03-28
 
@@ -523,8 +523,8 @@ Bug fixes:
  * Fixed an endless sleep in DBus::Main.run ([bsc#537401][]).
  * Added details to PacketMarshaller exceptions ([bsc#538050][]).
 
-[bsc#537401]: https://bugzilla.novell.com/show_bug.cgi?id=537401
-[bsc#538050]: https://bugzilla.novell.com/show_bug.cgi?id=538050
+[bsc#537401]: https://bugzilla.suse.com/show_bug.cgi?id=537401
+[bsc#538050]: https://bugzilla.suse.com/show_bug.cgi?id=538050
 
 ## Ruby D-Bus "I'm not dead" 0.2.9 - 2009-08-26
 

--- a/lib/dbus/message_queue.rb
+++ b/lib/dbus/message_queue.rb
@@ -26,8 +26,7 @@ module DBus
       @address = address
       @buffer = ""
       # Reduce allocations by using a single buffer for our socket
-      @read_buffer = String.new("", capacity: MSG_BUF_SIZE)
-      @read_buffer.force_encoding(Encoding::BINARY)
+      @read_buffer = String.new(capacity: MSG_BUF_SIZE)
       @is_tcp = false
       @mutex = Mutex.new
       connect

--- a/lib/dbus/message_queue.rb
+++ b/lib/dbus/message_queue.rb
@@ -18,10 +18,16 @@ module DBus
     # The socket that is used to connect with the bus.
     attr_reader :socket
 
+    # The buffer size for messages.
+    MSG_BUF_SIZE = 4096
+
     def initialize(address)
       DBus.logger.debug "MessageQueue: #{address}"
       @address = address
       @buffer = ""
+      # Reduce allocations by using a single buffer for our socket
+      @read_buffer = String.new("", capacity: MSG_BUF_SIZE)
+      @read_buffer.force_encoding(Encoding::BINARY)
       @is_tcp = false
       @mutex = Mutex.new
       connect
@@ -157,15 +163,12 @@ module DBus
       ret
     end
 
-    # The buffer size for messages.
-    MSG_BUF_SIZE = 4096
-
     # Fill (append) the buffer from data that might be available on the
     # socket.
     # @return [void]
     # @raise EOFError
     def buffer_from_socket_nonblock
-      @buffer += @socket.read_nonblock(MSG_BUF_SIZE)
+      @buffer += @socket.read_nonblock(MSG_BUF_SIZE, @read_buffer)
     rescue EOFError
       raise # the caller expects it
     rescue Errno::EAGAIN


### PR DESCRIPTION
Some services call dispatch_message_queue (nonblocking) a lot and memory_profiler.gem shows many string allocations in the socket library.

Preallocating our own buffer helps with that.