### PR TITLE
Respect env RUBY_DBUS_ENDIANNESS=B (or =l) for outgoing messages.

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,7 @@
 
 Bug fixes:
  * Reduce socket buffer allocations ([#129][]).
+ * Message#marshall speedup: don't marshall the body twice.
 
 [#129]: https://github.com/mvidner/ruby-dbus/pull/129
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+Features:
+ * Respect env RUBY_DBUS_ENDIANNESS=B (or =l) for outgoing messages.
+
 Bug fixes:
  * Reduce socket buffer allocations ([#129][]).
  * Message#marshall speedup: don't marshall the body twice.

--- a/lib/dbus.rb
+++ b/lib/dbus.rb
@@ -10,6 +10,21 @@
 # License, version 2.1 as published by the Free Software Foundation.
 # See the file "COPYING" for the exact licensing terms.
 
+module DBus
+  # Byte signifying big endianness.
+  BIG_END = "B"
+  # Byte signifying little endianness.
+  LIL_END = "l"
+
+  # Byte signifying the host's endianness.
+  HOST_END = if [0x01020304].pack("L").unpack1("V") == 0x01020304
+               LIL_END
+             else
+               BIG_END
+             end
+end
+# ^ That's because dbus/message needs HOST_END early
+
 require_relative "dbus/api_options"
 require_relative "dbus/auth"
 require_relative "dbus/bus"
@@ -40,18 +55,6 @@ require "socket"
 module DBus
   # Default socket name for the system bus.
   SYSTEM_BUS_ADDRESS = "unix:path=/var/run/dbus/system_bus_socket"
-
-  # Byte signifying big endianness.
-  BIG_END = "B"
-  # Byte signifying little endianness.
-  LIL_END = "l"
-
-  # Byte signifying the host's endianness.
-  HOST_END = if [0x01020304].pack("L").unpack1("V") == 0x01020304
-               LIL_END
-             else
-               BIG_END
-             end
 
   # Comparing symbols is faster than strings
   # @return [:little,:big]

--- a/lib/dbus/message.rb
+++ b/lib/dbus/message.rb
@@ -165,11 +165,11 @@ module DBus
         raise InvalidDestinationName
       end
 
-      params = PacketMarshaller.new
-      @params.each do |param|
-        params.append(param[0], param[1])
+      params_marshaller = PacketMarshaller.new
+      @params.each do |type, value|
+        params_marshaller.append(type, value)
       end
-      @body_length = params.packet.bytesize
+      @body_length = params_marshaller.packet.bytesize
 
       marshaller = PacketMarshaller.new
       marshaller.append(Type::BYTE, HOST_END.ord)
@@ -191,10 +191,8 @@ module DBus
       marshaller.append("a(yv)", headers)
 
       marshaller.align(8)
-      @params.each do |param|
-        marshaller.append(param[0], param[1])
-      end
-      marshaller.packet
+
+      marshaller.packet + params_marshaller.packet
     end
 
     # Unmarshall a packet contained in the buffer _buf_ and set the

--- a/lib/dbus/message.rb
+++ b/lib/dbus/message.rb
@@ -10,6 +10,8 @@
 # License, version 2.1 as published by the Free Software Foundation.
 # See the file "COPYING" for the exact licensing terms.
 
+require_relative "raw_message"
+
 # = D-Bus main module
 #
 # Module containing all the D-Bus modules and classes.
@@ -144,6 +146,10 @@ module DBus
       @params << [type, val]
     end
 
+    # "l" or "B"
+    ENDIANNESS_CHAR = ENV.fetch("RUBY_DBUS_ENDIANNESS", HOST_END)
+    ENDIANNESS = RawMessage.endianness(ENDIANNESS_CHAR)
+
     # FIXME: what are these? a message element constant enumeration?
     # See method below, in a message, you have and array of optional parameters
     # that come with an index, to determine their meaning. The values are in
@@ -165,14 +171,14 @@ module DBus
         raise InvalidDestinationName
       end
 
-      params_marshaller = PacketMarshaller.new
+      params_marshaller = PacketMarshaller.new(endianness: ENDIANNESS)
       @params.each do |type, value|
         params_marshaller.append(type, value)
       end
       @body_length = params_marshaller.packet.bytesize
 
-      marshaller = PacketMarshaller.new
-      marshaller.append(Type::BYTE, HOST_END.ord)
+      marshaller = PacketMarshaller.new(endianness: ENDIANNESS)
+      marshaller.append(Type::BYTE, ENDIANNESS_CHAR.ord)
       marshaller.append(Type::BYTE, @message_type)
       marshaller.append(Type::BYTE, @flags)
       marshaller.append(Type::BYTE, @protocol)

--- a/spec/raw_message_spec.rb
+++ b/spec/raw_message_spec.rb
@@ -1,0 +1,32 @@
+#!/usr/bin/env rspec
+# frozen_string_literal: true
+
+require_relative "spec_helper"
+require "dbus"
+
+# Pedantic full coverage test.
+# The happy paths are covered via calling classes
+describe DBus::RawMessage do
+  describe ".endianness" do
+    it "returns :little for 'l'" do
+      expect(described_class.endianness("l")).to eq :little
+    end
+
+    it "returns :big for 'B'" do
+      expect(described_class.endianness("B")).to eq :big
+    end
+
+    it "raises for other strings" do
+      expect { described_class.endianness("m") }
+        .to raise_error(DBus::InvalidPacketException, /Incorrect endianness/)
+    end
+  end
+
+  describe "#align" do
+    it "raises for values other than 1 2 4 8" do
+      subject = described_class.new("l")
+      expect { subject.align(3) }.to raise_error(ArgumentError)
+      expect { subject.align(16) }.to raise_error(ArgumentError)
+    end
+  end
+end


### PR DESCRIPTION
also:  Message#marshall speedup: don't marshall the body twice.