### PR TITLE
Make introspection XML better diffable for docs

### DIFF
--- a/lib/dbus/introspect.rb
+++ b/lib/dbus/introspect.rb
@@ -224,11 +224,13 @@ module DBus
       xml = "    <method name=\"#{@name}\">\n"
       @params.each do |param|
         name = param.name ? "name=\"#{param.name}\" " : ""
-        xml += "      <arg #{name}direction=\"in\" type=\"#{param.type}\"/>\n"
+        xml += "      <arg #{name}direction=\"in\" type=\"#{param.type}\">\n" \
+               "      </arg>\n"
       end
       @rets.each do |param|
         name = param.name ? "name=\"#{param.name}\" " : ""
-        xml += "      <arg #{name}direction=\"out\" type=\"#{param.type}\"/>\n"
+        xml += "      <arg #{name}direction=\"out\" type=\"#{param.type}\">\n" \
+               "      </arg>\n"
       end
       xml += "    </method>\n"
       xml
@@ -258,7 +260,8 @@ module DBus
       xml = "    <signal name=\"#{@name}\">\n"
       @params.each do |param|
         name = param.name ? "name=\"#{param.name}\" " : ""
-        xml += "      <arg #{name}type=\"#{param.type}\"/>\n"
+        xml += "      <arg #{name}type=\"#{param.type}\">\n" \
+               "      </arg>\n"
       end
       xml += "    </signal>\n"
       xml
@@ -300,7 +303,8 @@ module DBus
 
     # Return introspection XML string representation of the property.
     def to_xml
-      "    <property type=\"#{@type}\" name=\"#{@name}\" access=\"#{@access}\"/>\n"
+      "    <property type=\"#{@type}\" name=\"#{@name}\" access=\"#{@access}\">\n" \
+      "    </property>\n"
     end
 
     # @param xml_node [AbstractXML::Node]

--- a/lib/dbus/proxy_object_factory.rb
+++ b/lib/dbus/proxy_object_factory.rb
@@ -42,6 +42,7 @@ module DBus
     end
 
     # Generates, sets up and returns the proxy object.
+    # @return [ProxyObject]
     def build
       po = ProxyObject.new(@bus, @dest, @path, api: @api)
       ProxyObjectFactory.introspect_into(po, @xml)


### PR DESCRIPTION
(This is useful for https://github.com/openSUSE/agama/pull/415)

That is, make separate closing tags, so that our output can be easier edited (and diffed line by line) to add XML documentation.

This is a small performance penalty for clients that do runtime introspection.
To avoid introspection, call ProxyObjectInterface#define_method, see examples/no-introspect/tracker-test.rb
(TODO: make it easier, all the way from the top)