### PR TITLE
Make it possible to load either rexml or nokogiri

### DIFF
--- a/lib/dbus/xml.rb
+++ b/lib/dbus/xml.rb
@@ -12,10 +12,16 @@
 # See the file "COPYING" for the exact licensing terms.
 
 # TODO: check if it is slow, make replaceable
-require "rexml/document"
+# make it possible to load either rexml or nokogiri
 begin
-  require "nokogiri"
+  require "rexml/document"
 rescue LoadError
+  require "nokogiri"
+else
+  begin
+    require "nokogiri"
+  rescue LoadError
+  end
 end
 
 module DBus


### PR DESCRIPTION
Make it possible to load either rexml or nokogiri.
Since nokogiri is preferably selected in the code, it should also be possible to work without rexml at all.
This is necessary for Ruby installations that don't have the bundled gems, e.g. when used on embedded devices.