### PR TITLE
Disable IPv6 test again

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+Bug fixes:
+ * Fix OBS building by disabling IPv6 tests, [#134][].
+
+[#134]: https://github.com/mvidner/ruby-dbus/pull/134
+
 ## Ruby D-Bus 0.22.0 - 2023-05-08
 
 Features:

--- a/spec/tools/dbus-limited-session.conf
+++ b/spec/tools/dbus-limited-session.conf
@@ -28,7 +28,10 @@
   <!--
   <listen>unix:runtime=yes</listen>
   -->
+  <!-- openSUSE Build Service does not set up IPv6 at build time -->
+  <!--
   <listen>tcp:host=%3a%3a1,family=ipv6</listen>
+  -->
   <listen>tcp:host=127.0.0.1</listen>
 
   <standard_session_servicedirs />


### PR DESCRIPTION
it does not work in openSUSE Build Service

https://build.opensuse.org/package/live_build_log/devel:languages:ruby:extensions/rubygem-ruby-dbus/openSUSE_Tumbleweed/x86_64
> [   19s] ~/rpmbuild/BUILDROOT/rubygem-ruby-dbus-0.22.0-50.1.x86_64/usr/lib64/ruby/gems/3.2.0/gems/ruby-dbus-0.22.0 ~/rpmbuild/BUILD
> [   19s] + rake test
> [   19s] ./test_env rake bare:spec
> [   19s] cd spec/tools
> [   19s] dbus-daemon[1904]: Failed to start message bus: Failed to lookup host/port: "::1:0": Name or service not known (-2)
> [   29s] dbus-daemon failed?
> 